### PR TITLE
fix(usfiscaldata): correct nonexistent Treasury auctions_query field names

### DIFF
--- a/skills/usfiscaldata/references/datasets-securities.md
+++ b/skills/usfiscaldata/references/datasets-securities.md
@@ -16,10 +16,11 @@ Historical data on Treasury securities auctions including bills, notes, bonds, T
 | `security_term` | STRING | e.g., "4-Week", "2-Year", "10-Year" |
 | `cusip` | STRING | CUSIP identifier |
 | `offering_amt` | CURRENCY | Amount offered |
-| `accepted_comp_bid_rate_amt` | PERCENTAGE | High accepted competitive bid rate |
+| `high_yield` | PERCENTAGE | High accepted yield (notes/bonds/TIPS; bills use `high_discnt_rate`) |
+| `int_rate` | PERCENTAGE | Coupon/interest rate of the security |
 | `bid_to_cover_ratio` | NUMBER | Bid-to-cover ratio |
 | `total_accepted_amt` | CURRENCY | Total accepted amount |
-| `indirect_bid_pct_accepted` | PERCENTAGE | Indirect bidder percentage |
+| `indirect_bidder_accepted` | CURRENCY | Indirect bidder amount accepted (USD) |
 | `issue_date` | DATE | Issue/settlement date |
 | `maturity_date` | DATE | Maturity date |
 

--- a/skills/usfiscaldata/references/examples.md
+++ b/skills/usfiscaldata/references/examples.md
@@ -69,22 +69,22 @@ result = fetch("/v1/accounting/od/auctions_query",
                filter="security_type:eq:Note,security_term:eq:10-Year",
                sort="-record_date", **{"page[size]": 20})
 df = pd.DataFrame(result["data"])
-numeric_cols = ["accepted_comp_bid_rate_amt", "bid_to_cover_ratio", 
-                "total_accepted_amt", "indirect_bid_pct_accepted"]
+numeric_cols = ["high_yield", "bid_to_cover_ratio", 
+                "total_accepted_amt", "indirect_bidder_accepted"]
 for col in numeric_cols:
     if col in df.columns:
         df[col] = pd.to_numeric(df[col], errors="coerce")
-print(df[["record_date", "security_term", "accepted_comp_bid_rate_amt", 
+print(df[["record_date", "security_term", "high_yield", 
          "bid_to_cover_ratio"]].head(10))
 
 # Auction yield trend: 2-year vs 10-year
 def get_auction_yields(term, n=24):
     result = fetch("/v1/accounting/od/auctions_query",
-                   fields="record_date,security_term,accepted_comp_bid_rate_amt",
+                   fields="record_date,security_term,high_yield",
                    filter=f"security_type:eq:Note,security_term:eq:{term}",
                    sort="-record_date", **{"page[size]": n})
     df = pd.DataFrame(result["data"])
-    df["yield"] = df["accepted_comp_bid_rate_amt"].astype(float)
+    df["yield"] = df["high_yield"].astype(float)
     df["date"] = pd.to_datetime(df["record_date"])
     return df[["date", "yield", "security_term"]].sort_values("date")
 


### PR DESCRIPTION
## Problem

The `usfiscaldata` skill's `auctions_query` documentation references field names that **do not exist** in the live U.S. Treasury Fiscal Data API. Any user who runs the documented reference table or the example snippet hits an unknown-field error (or a silent empty column).

Affected files:
- `skills/usfiscaldata/references/datasets-securities.md`
- `skills/usfiscaldata/references/examples.md`

## Fixes

| Documented (wrong) | Actual API field | Note |
|---|---|---|
| `accepted_comp_bid_rate_amt` | `high_yield` | High accepted yield (notes/bonds/TIPS). Coupon is `int_rate`; bills use `high_discnt_rate`/`high_investment_rate`. |
| `indirect_bid_pct_accepted` | `indirect_bidder_accepted` | Also a **USD amount (CURRENCY)**, not a percentage — there is no indirect-bidder percentage field. |

The example's yield-curve snippet now runs against the real schema instead of erroring.

## Verification

Confirmed against live responses (most recent 10-Year note auctions) from:

```
https://api.fiscaldata.treasury.gov/services/api/fiscal_service/v1/accounting/od/auctions_query?filter=security_term:eq:10-Year,security_type:eq:Note&sort=-record_date
```

Sample returned values: `high_yield=4.468`, `int_rate=4.375`, `indirect_bidder_accepted=26775518000` (2026-05-15). Enumerated all 113 fields on the record — neither `accepted_comp_bid_rate_amt` nor `indirect_bid_pct_accepted` is present.

Docs-only change; no code/skill behavior altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
