### PR TITLE
Add MiniMax autoskill backend

### DIFF
--- a/skills/autoskill/config.yaml
+++ b/skills/autoskill/config.yaml
@@ -6,7 +6,7 @@
 # Local is the default — your screen content never leaves the machine.
 # Cloud backends (claude, foundry) are available for users who explicitly
 # opt in; see the backend sections below.
-backend: local    # local | claude | foundry
+backend: local    # local | claude | foundry | minimax
 
 # Per-backend settings. Only the selected backend's block is used.
 local:
@@ -25,6 +25,15 @@ foundry:
   endpoint: https://foundry.example.com/anthropic
   model: claude-opus-4-7
   # api_key read from FOUNDRY_API_KEY env var
+
+minimax:
+  region: global_en        # global_en | cn_zh
+  protocol: openai         # openai | anthropic
+  model: MiniMax-M3        # MiniMax-M3 | MiniMax-M2.7
+  thinking: adaptive       # MiniMax-M3: adaptive | disabled; MiniMax-M2.7: always_on
+  # api_key read from MINIMAX_API_KEY env var
+  # Optional endpoint override; defaults come from region + protocol.
+  # endpoint: https://api.minimax.io/v1
 
 # Screenpipe HTTP endpoint. For TLS, point this at your local Caddy proxy
 # (see references/https-proxy.md).

--- a/skills/autoskill/scripts/backends.py
+++ b/skills/autoskill/scripts/backends.py
@@ -6,6 +6,45 @@ from urllib.parse import urlparse
 import httpx
 
 
+MINIMAX_REGIONS = {
+    "global_en": {
+        "openai_base_url": "https://api.minimax.io/v1",
+        "anthropic_base_url": "https://api.minimax.io/anthropic",
+    },
+    "cn_zh": {
+        "openai_base_url": "https://api.minimaxi.com/v1",
+        "anthropic_base_url": "https://api.minimaxi.com/anthropic",
+    },
+}
+
+MINIMAX_MODELS = {
+    "MiniMax-M3": {
+        "context_window": 1_000_000,
+        "pricing_usd_per_million_tokens": {
+            "input": 0.6,
+            "output": 2.4,
+            "cache_read": 0.12,
+            "cache_write": None,
+        },
+        "input_modalities": ("text", "image", "video"),
+        "thinking": ("adaptive", "disabled"),
+        "default_thinking": "adaptive",
+    },
+    "MiniMax-M2.7": {
+        "context_window": 204_800,
+        "pricing_usd_per_million_tokens": {
+            "input": 0.3,
+            "output": 1.2,
+            "cache_read": 0.06,
+            "cache_write": 0.375,
+        },
+        "input_modalities": ("text",),
+        "thinking": ("always_on",),
+        "default_thinking": "always_on",
+    },
+}
+
+
 def _is_loopback(host):
     if host in ("localhost", ""):
         return True
@@ -91,6 +130,94 @@ class LocalBackend:
         return payload["choices"][0]["message"]["content"]
 
 
+class MiniMaxBackend:
+    def __init__(self, api_key, model, endpoint, protocol="openai", thinking=None, client=None):
+        if model not in MINIMAX_MODELS:
+            supported = ", ".join(sorted(MINIMAX_MODELS))
+            raise ValueError(f"unsupported MiniMax model: {model!r}; supported: {supported}")
+
+        model_config = MINIMAX_MODELS[model]
+        thinking = thinking or model_config["default_thinking"]
+        if thinking not in model_config["thinking"]:
+            supported = ", ".join(model_config["thinking"])
+            raise ValueError(
+                f"unsupported MiniMax thinking mode for {model}: {thinking!r}; "
+                f"supported: {supported}"
+            )
+
+        if protocol not in ("openai", "anthropic"):
+            raise ValueError(f"unsupported MiniMax protocol: {protocol!r}")
+
+        self.api_key = api_key
+        self.model = model
+        self.endpoint = endpoint
+        self.protocol = protocol
+        self.thinking = thinking
+        self.metadata = model_config
+        self.client = client or httpx.Client(base_url=endpoint, timeout=60.0)
+
+    def __call__(self, prompt):
+        if self.protocol == "anthropic":
+            return self._call_anthropic(prompt)
+        return self._call_openai(prompt)
+
+    def _thinking_payload(self):
+        if self.thinking == "disabled":
+            return {"thinking": {"type": "disabled"}}
+        if self.thinking == "adaptive":
+            return {"thinking": {"type": "enabled", "mode": "adaptive"}}
+        return {"thinking": {"type": "enabled"}}
+
+    def _call_openai(self, prompt):
+        response = self.client.post(
+            "/chat/completions",
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "content-type": "application/json",
+            },
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+                **self._thinking_payload(),
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload["choices"][0]["message"]["content"]
+
+    def _call_anthropic(self, prompt):
+        response = self.client.post(
+            "/v1/messages",
+            headers={
+                "x-api-key": self.api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json={
+                "model": self.model,
+                "max_tokens": 4096,
+                "messages": [{"role": "user", "content": prompt}],
+                **self._thinking_payload(),
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload["content"][0]["text"]
+
+
+def _minimax_endpoint(config):
+    region = config.get("region", "global_en")
+    protocol = config.get("protocol", "openai")
+    if region not in MINIMAX_REGIONS:
+        supported = ", ".join(sorted(MINIMAX_REGIONS))
+        raise ValueError(f"unsupported MiniMax region: {region!r}; supported: {supported}")
+    if protocol == "openai":
+        return MINIMAX_REGIONS[region]["openai_base_url"]
+    if protocol == "anthropic":
+        return MINIMAX_REGIONS[region]["anthropic_base_url"]
+    raise ValueError(f"unsupported MiniMax protocol: {protocol!r}")
+
+
 def make_backend(config):
     kind = config.get("backend")
     if kind == "claude":
@@ -112,5 +239,19 @@ def make_backend(config):
     if kind == "local":
         l = config.get("local", {})
         return LocalBackend(endpoint=check_remote_endpoint(l["endpoint"], "local"), model=l["model"])
+
+    if kind == "minimax":
+        api_key = os.environ.get("MINIMAX_API_KEY")
+        if not api_key:
+            raise RuntimeError("MINIMAX_API_KEY environment variable not set")
+        m = config.get("minimax", {})
+        endpoint = check_remote_endpoint(m.get("endpoint") or _minimax_endpoint(m), "minimax")
+        return MiniMaxBackend(
+            api_key=api_key,
+            model=m.get("model", "MiniMax-M3"),
+            endpoint=endpoint,
+            protocol=m.get("protocol", "openai"),
+            thinking=m.get("thinking"),
+        )
 
     raise ValueError(f"unknown backend: {kind!r}")

--- a/skills/autoskill/scripts/doctor.py
+++ b/skills/autoskill/scripts/doctor.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import httpx
 
-_VALID_BACKENDS = {"local", "claude", "foundry"}
+_VALID_BACKENDS = {"local", "claude", "foundry", "minimax"}
 
 
 def default_screenpipe_probe(config):
@@ -41,6 +41,10 @@ def default_llm_probe(config):
         if not os.environ.get("FOUNDRY_API_KEY"):
             return ("error", "FOUNDRY_API_KEY not set")
         return ("ok", "FOUNDRY_API_KEY present (not probed)")
+    if kind == "minimax":
+        if not os.environ.get("MINIMAX_API_KEY"):
+            return ("error", "MINIMAX_API_KEY not set")
+        return ("ok", "MINIMAX_API_KEY present (not probed)")
     return ("error", f"unknown backend: {kind!r}")
 
 

--- a/tests/autoskill/test_backends.py
+++ b/tests/autoskill/test_backends.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
 
-from backends import ClaudeBackend, LocalBackend, make_backend
+from backends import ClaudeBackend, LocalBackend, MiniMaxBackend, make_backend
 
 
 def _mock_client(handler, base_url=""):
@@ -110,6 +110,86 @@ def test_make_backend_returns_local_backend_for_local_config():
     assert backend.model == "qwen2.5:14b"
 
 
+def test_minimax_backend_posts_to_openai_compatible_endpoint():
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(200, json={
+            "choices": [{"message": {"content": "minimax reply"}}]
+        })
+
+    backend = MiniMaxBackend(
+        api_key="k",
+        model="MiniMax-M3",
+        endpoint="https://api.minimax.io/v1",
+        protocol="openai",
+        thinking="disabled",
+        client=_mock_client(handler, base_url="https://api.minimax.io/v1"),
+    )
+    result = backend("prompt")
+
+    assert result == "minimax reply"
+    assert calls[0].url.path.endswith("/chat/completions")
+    assert calls[0].headers["Authorization"] == "Bearer k"
+    import json as _json
+    payload = _json.loads(calls[0].read())
+    assert payload["model"] == "MiniMax-M3"
+    assert payload["thinking"] == {"type": "disabled"}
+    assert payload["messages"][0]["content"] == "prompt"
+
+
+def test_minimax_backend_posts_to_anthropic_compatible_endpoint():
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(200, json={"content": [{"type": "text", "text": "ok"}]})
+
+    backend = MiniMaxBackend(
+        api_key="k",
+        model="MiniMax-M2.7",
+        endpoint="https://api.minimaxi.com/anthropic",
+        protocol="anthropic",
+        client=_mock_client(handler, base_url="https://api.minimaxi.com/anthropic"),
+    )
+    result = backend("hi")
+
+    assert result == "ok"
+    assert str(calls[0].url).startswith("https://api.minimaxi.com/anthropic/v1/messages")
+    import json as _json
+    payload = _json.loads(calls[0].read())
+    assert payload["model"] == "MiniMax-M2.7"
+    assert payload["thinking"] == {"type": "enabled"}
+
+
+def test_minimax_backend_rejects_unsupported_thinking_mode():
+    with pytest.raises(ValueError, match="thinking mode"):
+        MiniMaxBackend(
+            api_key="k",
+            model="MiniMax-M2.7",
+            endpoint="https://api.minimax.io/v1",
+            thinking="disabled",
+        )
+
+
+def test_make_backend_returns_minimax_backend_with_cn_endpoint(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "k")
+    backend = make_backend({
+        "backend": "minimax",
+        "minimax": {
+            "region": "cn_zh",
+            "protocol": "anthropic",
+            "model": "MiniMax-M2.7",
+        },
+    })
+
+    assert isinstance(backend, MiniMaxBackend)
+    assert backend.model == "MiniMax-M2.7"
+    assert backend.protocol == "anthropic"
+    assert "api.minimaxi.com" in str(backend.client.base_url)
+
+
 def test_make_backend_raises_on_unknown_backend():
     with pytest.raises(ValueError, match="unknown backend"):
         make_backend({"backend": "mystery"})
@@ -119,3 +199,9 @@ def test_make_backend_raises_when_anthropic_key_missing(monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
         make_backend({"backend": "claude", "claude": {"model": "m"}})
+
+
+def test_make_backend_raises_when_minimax_key_missing(monkeypatch):
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="MINIMAX_API_KEY"):
+        make_backend({"backend": "minimax", "minimax": {"model": "MiniMax-M3"}})

--- a/tests/autoskill/test_doctor.py
+++ b/tests/autoskill/test_doctor.py
@@ -75,6 +75,22 @@ def test_check_flags_unknown_backend(tmp_path: Path):
     assert "mystery" in result["config"][1]
 
 
+def test_check_accepts_minimax_backend(tmp_path: Path):
+    config = {
+        "backend": "minimax",
+        "minimax": {"model": "MiniMax-M3"},
+        "screenpipe": {"url": "http://localhost:3030"},
+    }
+    result = check(
+        config,
+        skills_dir=tmp_path,
+        screenpipe_probe=_ok_probe,
+        llm_probe=_ok_probe,
+    )
+
+    assert result["config"] == ("ok", "backend=minimax")
+
+
 def test_cli_all_green_returns_zero(tmp_path: Path, capsys, monkeypatch):
     import yaml as _yaml
     conf_path = tmp_path / "c.yaml"


### PR DESCRIPTION
Reason: Add a MiniMax backend path for autoskill synthesis.

Changes:
- Adds MiniMax model metadata, regional endpoint defaults, protocol selection, and thinking-mode validation.
- Wires the autoskill backend factory, doctor check, and sample config to the new backend.
- Adds focused offline tests for request routing and validation.

Checks:
- uv run --project "$REPO_DIR" pytest "$REPO_DIR/tests/autoskill/test_backends.py" "$REPO_DIR/tests/autoskill/test_doctor.py"
- uv run --project "$REPO_DIR" python -m py_compile "$REPO_DIR/skills/autoskill/scripts/backends.py" "$REPO_DIR/skills/autoskill/scripts/doctor.py" "$REPO_DIR/tests/autoskill/test_backends.py" "$REPO_DIR/tests/autoskill/test_doctor.py"
