### PR TITLE
genomic-intelligence: reconcile the skill against the live /v1 contract (1.1)

### DIFF
--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -2,7 +2,7 @@
 name: genomic-intelligence
 description: "Predict regulatory features, gene structure, and expression directly from DNA sequence using Genomic Intelligence's hosted transformer DNA language models — no local GPU or model weights. Six tasks over a REST API and a hosted MCP server (keyless public demo): promoter regions, splice donor/acceptor sites, enhancer activity, chromatin state, sequence-to-expression (log TPM), and de-novo gene annotation, plus a composite find-genes-then-predict-expression workflow. Use when the user has a gene symbol, a genomic region, or a DNA/FASTA sequence and wants any of these predictions, mentions Genomic Intelligence, genomicintelligence.ai, api.genomicintelligence.ai, or mcp.genomicintelligence.ai."
 license: MIT
-compatibility: Python 3.10+ with the `requests` library for the REST path (no dedicated SDK). Network access required. The REST `/v1` API needs a `GI_API_KEY` (a `gi_` bearer); the hosted MCP server at mcp.genomicintelligence.ai/mcp works keyless against a capped public demo quota, key optional.
+compatibility: Python 3.10+ with the `requests` library for the REST path (no dedicated SDK). Network access required. The REST `/v1` API needs a `GI_API_KEY` (a `gi_` bearer); the hosted MCP server at mcp.genomicintelligence.ai/mcp works keyless against a rate- and concurrency-limited public demo tier, key optional.
 metadata:
   version: "1.1"
   skill-author: Genomic Intelligence
@@ -12,7 +12,7 @@ metadata:
     envVars:
     - name: GI_API_KEY
       required: false
-      description: Optional gi_ bearer key for the REST /v1 API and a higher MCP quota. The hosted MCP demo runs keyless; request a key at contact@genomicintelligence.ai.
+      description: Optional gi_ bearer key for the REST /v1 API and higher MCP rate and concurrency limits. The hosted MCP demo runs keyless; request a key at contact@genomicintelligence.ai.
 ---
 
 # Genomic Intelligence — DNA Sequence Models
@@ -44,18 +44,18 @@ Use GI when the user has DNA and wants a model prediction:
 Not for local alignment, variant calling, or file I/O — use a local tool
 (BioPython, bcftools) for those. GI is for **model inference from sequence**.
 
-> For research and development use, **not clinical or diagnostic decisions**.
+> Research and development use. Not for clinical or diagnostic decisions.
 
 ## Two ways to call GI
 
-### Hosted MCP server (best for AI agents — keyless)
+### Hosted MCP server (keyless; preferred on MCP hosts)
 
 GI hosts an MCP server at `https://mcp.genomicintelligence.ai/mcp` (Streamable
 HTTP). When your agent host supports MCP, prefer it: it works **keyless** against
-a capped public demo quota (zero setup), and an optional `gi_` bearer key raises
-the quota. It exposes acquisition tools that return a **sequence handle**
-(`sequence_ref`) and `predict_*` tools that take that handle — so large sequences
-never bloat the context. See [MCP workflow](#mcp-workflow-handle-based) below and
+a rate- and concurrency-limited public demo tier, and an optional `gi_` bearer
+key raises those limits. It exposes acquisition tools that return a **sequence handle**
+(`sequence_ref`) and `predict_*` tools that take that handle, so large sequences
+stay out of the context. See [MCP workflow](#mcp-workflow-handle-based) below and
 `references/mcp.md`.
 
 ### REST API (universal)
@@ -86,9 +86,9 @@ Each task is **its own published operation** with its own request schema, its ow
 minimum length, and its own closed `options` object — `POST
 /v1/tasks/promoter/predict`, `/v1/tasks/splice/predict`,
 `/v1/tasks/enhancer/predict`, `/v1/tasks/chromatin/predict`,
-`/v1/tasks/annotation/predict`, `/v1/tasks/expression/predict`. The URLs are the
-same strings clients already POST to, so no URL construction changes; the shared
-`PredictRequest` schema is gone. Body is `{sequence, sequence_name?, model?,
+`/v1/tasks/annotation/predict`, `/v1/tasks/expression/predict`. Each path is a
+literal string, so nothing needs to be constructed, and there is no shared
+`PredictRequest` schema. Body is `{sequence, sequence_name?, model?,
 options?}`, returning a `{data, meta}` envelope. What differs per task:
 
 | Task | Recommended mode | Accepted length | `context_window_bp` | Notes |
@@ -105,8 +105,8 @@ options?}`, returning a `{data, meta}` envelope. What differs per task:
 **The minimum is admission control, not regime.** A request above the floor but
 shorter than the selected model's `bio_spec.context_window_bp` is *accepted and
 scored* — against a window padded out to the context window. Enhancer is the
-sharp case: the bound is 50 bp (DeepSTARR's gate) but the context window is
-249 bp, so 50–248 bp is scored mostly on padding. Compare your length against
+sharp case: the floor is 50 bp but the context window is 249 bp, so 50–248 bp is
+scored mostly on padding. Compare your length against
 `context_window_bp` from `GET /v1/tasks/{task}/models` to know whether the model
 saw real sequence. Longer-than-context input is fine — the scanner steps a
 prediction window at a time and pads only the final partial window.
@@ -130,7 +130,7 @@ never ignored:
 | expression | `description` — **required**, and the only key |
 
 `Prefer: respond-async` is a declared header on **all six** predict operations
-and on the composite, not just `annotation` — see [Async](#async-any-task-annotation-always).
+and on the composite, not just `annotation` — see [Async](#async-any-task-recommended-for-annotation).
 
 **Omit `model` and the API uses the task's default** — that is the recommended
 call. Default model IDs are intentionally **not** documented here: defaults
@@ -159,7 +159,7 @@ or query parameter:
   is required, and is the **only** key `expression` accepts inside `options`.
   Unknown top-level body fields are rejected too.
 
-> Gotcha: the legal `tss_index` range is wide, so an offset that is merely
+> Note: the legal `tss_index` range is wide, so an offset that is merely
 > *wrong* (counted over raw FASTA characters including newlines, or relative to
 > a locus start rather than the submitted slice) does not error — it returns a
 > confident `200` for the wrong window. Assert on
@@ -190,14 +190,14 @@ You rarely start from a raw 9,198 bp string. Acquire sequence first:
   for REST. (`load_local_fasta` exists only in local deployments, not on the
   hosted server.)
 - **A demo sequence** → MCP `load_demo_sequence(name=...)` returns a ready handle
-  (great for a keyless smoke test); `name` is required.
+  for a keyless smoke test; `name` is required.
 
 See `references/sequence-acquisition.md` for the exact Ensembl calls and the
 expression-window math.
 
 ## Core REST workflow
 
-Sync tasks (promoter, splice, enhancer, chromatin, expression) are one call:
+Called synchronously — the default for every task — a prediction is one call:
 
 ```python
 import os, requests
@@ -235,7 +235,7 @@ out = predict("expression", locus_seq, "HBB",
 print(out["meta"]["task_specific_counts"]["scored_window"])   # confirm the window scored
 ```
 
-### Async (any task; annotation always)
+### Async (any task; recommended for annotation)
 
 `Prefer: respond-async` is a declared header parameter on all six predict
 operations and on the composite. A `202` carries the same `{data, meta}` envelope
@@ -269,7 +269,7 @@ the context:
 
 ```
 # 1. Acquire a sequence handle (each returns a sequence_ref):
-load_demo_sequence(name="promoter_tp53")  # keyless smoke test; `name` is REQUIRED
+load_demo_sequence(name="promoter_tp53")  # keyless smoke test; name is required
 fetch_ensembl_sequence(gene="TP53")       # gene symbol or Ensembl ID -> handle
 fetch_region(region="chr11:5,225,000-5,235,000")   # coordinates -> handle
 fetch_gene_for_expression(gene="HBB")     # TSS-centred 9,198 bp handle for expression
@@ -343,9 +343,8 @@ the header first remains a safe default.
 Every response carries `RateLimit-Limit`, `RateLimit-Remaining`,
 `RateLimit-Reset`, `RateLimit-Policy`; a `429` adds `Retry-After`.
 
-> This describes the contract served from `2026.08.19.4`, verified live. The API
-> is pre-GA and still moving; `info.version` in `/v1/openapi.json` reports what a
-> given deployment actually serves, and is the arbiter if anything here disagrees.
+> The contract moves. `info.version` in `/v1/openapi.json` reports what a given
+> deployment serves, and that document is the arbiter if anything here disagrees.
 
 ## Reference files
 

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -92,7 +92,7 @@ envelope. What differs per task:
 | `splice` | sync | 1–500,000 bp | donor/acceptor sites (long-context BigBird) |
 | `enhancer` | sync | 1–500,000 bp | dev + housekeeping scores (DeepSTARR, *Drosophila*) |
 | `chromatin` | sync | 1–500,000 bp | hundreds of tracks (DeepSEA) |
-| `expression` | sync | **exactly 9,198 bp** | log(TPM+1); needs a cell-type `description` |
+| `expression` | sync | **9,198–500,000 bp** | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
 | `annotation` | **async** | 1–500,000 bp | de-novo transcripts; submit + poll |
 
 **Omit `model` and the API uses the task's default** — that is the recommended
@@ -103,13 +103,33 @@ tasks), discover IDs at call time with `GET /v1/tasks/{task}/models` (REST) or
 `list_models` (MCP) — and **never invent one**. Full per-task output shapes are
 in `references/tasks.md`.
 
-Two hard rules the model enforces:
+`expression` is the one task with its own published operation (same URL,
+`POST /v1/tasks/expression/predict`, its own request schema). Three hard rules
+it enforces — every violation is a `422`, nothing is padded or clamped, and
+there is no opt-out flag, header, or query parameter:
 
-- **`expression` needs exactly 9,198 bp**, a window **centred on the TSS**
-  (4,599 upstream + TSS + 4,598 downstream). Any other length is rejected. Use the acquisition helpers below to
-  build it — do not truncate by hand.
-- **`expression` needs a `description`** — a cell-type / assay string (e.g.
-  `"K562 cells"`), passed as `options.description`.
+- **It always scores exactly one 9,198 bp TSS-centred window** —
+  `sequence[tss_index-4599 : tss_index+4599]`. The endpoint itself accepts
+  **9,198–500,000 bp**; anything below 9,198 bp is rejected outright.
+- **`tss_index` is required unless the sequence is exactly 9,198 bp.** It is the
+  0-based TSS offset into the **whitespace-stripped** sequence, bounded by
+  `4599 ≤ tss_index ≤ len(sequence) − 4599`. At exactly 9,198 bp it defaults to
+  4,599, the only legal value there. So you may submit a whole locus (up to
+  500 kb) and let the server cut the window — but the server does **not**
+  discover the TSS for you (that is the composite workflow's job), and does
+  **not** reverse-complement: submit gene-sense sequence.
+- **`options.description`** — a cell-type / assay string (e.g. `"K562 cells"`) —
+  is required, and is the **only** key `expression` accepts inside `options`.
+  Unknown top-level body fields are rejected too.
+
+> Gotcha: the legal `tss_index` range is wide, so an offset that is merely
+> *wrong* (counted over raw FASTA characters including newlines, or relative to
+> a locus start rather than the submitted slice) does not error — it returns a
+> confident `200` for the wrong window. Assert on
+> `meta.task_specific_counts.scored_window` / `.tss_index` in the response.
+> Also note `data.input.sequence_length` is the **scored** length (always
+> 9,198); the length you submitted is `data.input.submitted_sequence_length`
+> (and `meta.sequence_length`).
 
 ## Sequence acquisition
 
@@ -120,8 +140,10 @@ You rarely start from a raw 9,198 bp string. Acquire sequence first:
   sequence (no key). REST users can query Ensembl REST directly. (`find_genes` is
   the annotation task, not an acquisition tool.)
 - **For `expression`** → use the TSS-centred fetch so the window is exactly
-  9,198 bp. MCP: `fetch_gene_for_expression` (handles the centring). Do not
-  build the window by hand.
+  9,198 bp. MCP: `fetch_gene_for_expression` (handles the centring). Otherwise
+  fetch a wider locus and pass the TSS as `tss_index` so the server cuts the
+  window — but compute that offset on the stripped nucleotide string, not on
+  file characters.
 - **From a local FASTA** → MCP `store_inline_sequence`, or read the file yourself
   for REST. (`load_local_fasta` exists only in local deployments, not on the
   hosted server.)
@@ -141,22 +163,29 @@ import os, requests
 BASE = os.environ.get("GI_BASE_URL", "https://api.genomicintelligence.ai")
 HEADERS = {"Authorization": f"Bearer {os.environ['GI_API_KEY']}"}
 
-def predict(task, sequence, sequence_name, model=None, options=None):
+def predict(task, sequence, sequence_name, model=None, options=None, tss_index=None):
     body = {"sequence": sequence, "sequence_name": sequence_name}
     if model:   body["model"] = model
     if options: body["options"] = options
+    if tss_index is not None: body["tss_index"] = tss_index   # expression only
     r = requests.post(f"{BASE}/v1/tasks/{task}/predict", headers=HEADERS, json=body)
-    r.raise_for_status()          # 400 invalid; 401 no/bad key; 413 too long; 429 rate limit
+    r.raise_for_status()          # 422 validation; 401 no/bad key; 413 too long; 429 rate limit
     return r.json()               # {"data": {...}, "meta": {...}}
 
 # Promoter:
 out = predict("promoter", seq, "TP53_region")
 print(out["data"]["summary"])
 
-# Expression — exactly 9,198 bp + a cell-type description:
+# Expression — a pre-cut 9,198 bp TSS-centred window (tss_index defaults to 4,599):
 out = predict("expression", tss_window_9198bp, "HBB",
               options={"description": "K562 cells"})
 print(out["data"]["prediction"]["expression_log_tpm"])
+
+# Expression — a whole locus; the server slices ±4,599 bp around the TSS you name.
+# tss_index is 0-based into the whitespace-stripped sequence.
+out = predict("expression", locus_seq, "HBB",
+              options={"description": "K562 cells"}, tss_index=tss_offset_in_locus)
+print(out["meta"]["task_specific_counts"]["scored_window"])   # confirm the window scored
 ```
 
 ### Async: annotation
@@ -224,11 +253,11 @@ composite:
 
 | Code | Meaning | Action |
 |---|---|---|
-| 400 | Invalid request / bad sequence | Check the body; expression must be exactly 9,198 bp and carry `description` |
+| 400 | Invalid request / bad sequence | Check the body shape |
 | 401 | Missing/invalid key (REST) | Set `GI_API_KEY`; or use the keyless MCP demo |
 | 413 | Sequence too long | Stay within the task's length bound (≤500,000 bp) |
 | 429 | Rate / concurrency cap | Back off and retry; ask GI to raise your tier |
-| 422 | Validation failed (`validation_failed`) | The most common failure: expression not exactly 9,198 bp, or a sequence below the model's minimum length |
+| 422 | Validation failed (`validation_failed`) | The most common failure: expression below 9,198 bp, a missing or out-of-range `tss_index`, or a missing `options.description` |
 | 5xx | Server error | Retry; if persistent, contact support |
 
 ## Reference files
@@ -240,4 +269,4 @@ composite:
 - `references/mcp.md` — the hosted MCP tool list, the handle-based flow, and the
   `gi://` resources.
 - `references/sequence-acquisition.md` — Ensembl fetch calls and the
-  expression-window (9,198 bp, TSS-centred) math.
+  expression-window (9,198 bp, TSS-centred) math, including `tss_index`.

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -333,15 +333,13 @@ composite:
 unlisted value as a generic failure, not a parse error.
 
 **Branch on `code`, never on `details` or `loc`.** `details` is keyed on the
-sibling `code`, and its shape for `validation_failed` has been in flux — some
-deployments return the `{errors: […]}` object the schema declares, others a bare
-FastAPI error array (`[{loc, msg, type}, …]`). Treat it as display-only and
-accept either shape; `code` is the stable discriminator.
+sibling `code`; for `validation_failed` it is the `{errors: [{loc, msg, type}, …]}`
+object the schema declares. Treat it as display-only — `code` is the stable
+discriminator.
 
-For correlation, prefer the `X-Request-Id` **header**: it is set on every
-response, whereas `error.request_id` is absent on some error paths (`413`
-historically omitted it). Reading the header first is correct on every
-deployment.
+For correlation, `error.request_id` and the `X-Request-Id` **header** are both
+set on every response, and success envelopes carry `meta.request_id`. Reading
+the header first remains a safe default.
 Every response carries `RateLimit-Limit`, `RateLimit-Remaining`,
 `RateLimit-Reset`, `RateLimit-Policy`; a `429` adds `Retry-After`.
 

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -82,18 +82,53 @@ means you hit a cap — back off and retry, or ask GI to raise your tier.
 
 ## The six tasks
 
-All REST tasks share one shape: `POST /v1/tasks/{task}/predict` with body
-`{sequence, sequence_name, model?, options?}`, returning a `{data, meta}`
-envelope. What differs per task:
+Each task is **its own published operation** with its own request schema, its own
+minimum length, and its own closed `options` object — `POST
+/v1/tasks/promoter/predict`, `/v1/tasks/splice/predict`,
+`/v1/tasks/enhancer/predict`, `/v1/tasks/chromatin/predict`,
+`/v1/tasks/annotation/predict`, `/v1/tasks/expression/predict`. The URLs are the
+same strings clients already POST to, so no URL construction changes; the shared
+`PredictRequest` schema is gone. Body is `{sequence, sequence_name?, model?,
+options?}`, returning a `{data, meta}` envelope. What differs per task:
 
-| Task | Mode | Length bound | Notes |
-|---|---|---|---|
-| `promoter` | sync | 1–500,000 bp | sliding-window promoter regions |
-| `splice` | sync | 1–500,000 bp | donor/acceptor sites (long-context BigBird) |
-| `enhancer` | sync | 1–500,000 bp | dev + housekeeping scores (DeepSTARR, *Drosophila*) |
-| `chromatin` | sync | 1–500,000 bp | hundreds of tracks (DeepSEA) |
-| `expression` | sync | **9,198–500,000 bp** | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
-| `annotation` | **async** | 1–500,000 bp | de-novo transcripts; submit + poll |
+| Task | Mode | Accepted length | Model context window | Notes |
+|---|---|---|---|---|
+| `promoter` | sync | 300–500,000 bp | 2,000 bp | sliding-window promoter regions |
+| `splice` | sync | 100–500,000 bp | 15,000 bp | donor/acceptor sites (long-context BigBird); strand-specific — feed transcript orientation |
+| `enhancer` | sync | 50–500,000 bp | 249 bp | dev + housekeeping scores (DeepSTARR, *Drosophila*) |
+| `chromatin` | sync | 200–500,000 bp | 1,000 bp | hundreds of tracks (DeepSEA) |
+| `expression` | sync | **9,198–500,000 bp** | 9,198 bp (fixed) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
+| `annotation` | **async** | 1,000–500,000 bp | n/a | de-novo transcripts; submit + poll |
+
+**The minimum is admission control, not regime.** A request above the floor but
+shorter than the selected model's `bio_spec.context_window_bp` is *accepted and
+scored* — against a window padded out to the context window. Enhancer is the
+sharp case: the bound is 50 bp (DeepSTARR's gate) but the context window is
+249 bp, so 50–248 bp is scored mostly on padding. Compare your length against
+`context_window_bp` from `GET /v1/tasks/{task}/models` to know whether the model
+saw real sequence. Longer-than-context input is fine — the scanner steps a
+prediction window at a time and pads only the final partial window.
+
+Under the floor and over the 500,000 bp cap are **both `422 validation_failed`**
+at `loc ["body","sequence"]`; over-length is *not* a `413`. All lengths are
+measured after whitespace is stripped, so a line-wrapped FASTA body can be pasted
+verbatim (a `>` header line still fails the alphabet check).
+
+`options` is typed and **closed** (`additionalProperties: false`) per task — an
+unknown key is a hard `422 validation_failed` with `type: "extra_forbidden"`,
+never ignored:
+
+| Task | `options` keys |
+|---|---|
+| promoter | `threshold` (0–1, default 0.5) |
+| splice | `threshold` (0–1, default 0.5), `site_types` (subset of `["donor","acceptor"]`, default both) |
+| enhancer | *(none)* |
+| chromatin | `threshold` (0–1, default 0.5) |
+| annotation | `batch_size` (1–128, default 8), `shift_coordinates`, `reverse_complement` (default true) |
+| expression | `description` — **required**, and the only key |
+
+`Prefer: respond-async` is a declared header on **all six** predict operations
+and on the composite, not just `annotation` — see [Async](#async-any-task-annotation-always).
 
 **Omit `model` and the API uses the task's default** — that is the recommended
 call. Default model IDs are intentionally **not** documented here: defaults
@@ -103,10 +138,10 @@ tasks), discover IDs at call time with `GET /v1/tasks/{task}/models` (REST) or
 `list_models` (MCP) — and **never invent one**. Full per-task output shapes are
 in `references/tasks.md`.
 
-`expression` is the one task with its own published operation (same URL,
-`POST /v1/tasks/expression/predict`, its own request schema). Three hard rules
-it enforces — every violation is a `422`, nothing is padded or clamped, and
-there is no opt-out flag, header, or query parameter:
+`expression` is the strictest of the six: alone among them its schema requires
+`options` as well as `sequence`. Three hard rules it enforces — every violation
+is a `422`, nothing is padded or clamped, and there is no opt-out flag, header,
+or query parameter:
 
 - **It always scores exactly one 9,198 bp TSS-centred window** —
   `sequence[tss_index-4599 : tss_index+4599]`. The endpoint itself accepts
@@ -130,6 +165,11 @@ there is no opt-out flag, header, or query parameter:
 > Also note `data.input.sequence_length` is the **scored** length (always
 > 9,198); the length you submitted is `data.input.submitted_sequence_length`
 > (and `meta.sequence_length`).
+>
+> Both `tss_index` violations — "required unless exactly 9,198 bp" and the range
+> check — come from a whole-model validator, so they report at `loc: ["body"]`,
+> **never** `body.tss_index`. Match on `error.code == "validation_failed"`; use
+> the message for display only, and never branch on `loc`.
 
 ## Sequence acquisition
 
@@ -168,8 +208,13 @@ def predict(task, sequence, sequence_name, model=None, options=None, tss_index=N
     if model:   body["model"] = model
     if options: body["options"] = options
     if tss_index is not None: body["tss_index"] = tss_index   # expression only
+    # Each task is its own published operation, but the URL string is unchanged.
     r = requests.post(f"{BASE}/v1/tasks/{task}/predict", headers=HEADERS, json=body)
-    r.raise_for_status()          # 422 validation; 401 no/bad key; 413 too long; 429 rate limit
+    # 422 validation_failed  — sequence under the task floor OR over 500,000 bp,
+    #                          bad tss_index, missing options.description,
+    #                          or ANY unknown body/options key (options is closed)
+    # 401 no/bad key · 404 unknown task · 413 body over 16 MiB · 429 rate limit
+    r.raise_for_status()
     return r.json()               # {"data": {...}, "meta": {...}}
 
 # Promoter:
@@ -188,10 +233,14 @@ out = predict("expression", locus_seq, "HBB",
 print(out["meta"]["task_specific_counts"]["scored_window"])   # confirm the window scored
 ```
 
-### Async: annotation
+### Async (any task; annotation always)
 
-`annotation` is submit-then-poll. Send `Prefer: respond-async`, get a `job_id`,
-poll until terminal:
+`Prefer: respond-async` is a declared header parameter on all six predict
+operations and on the composite. A `202` carries the same `{data, meta}` envelope
+as a sync `200`, with `data = {job_id, status: "accepted", links}`; the job id is
+also in the `Content-Location` and `X-Job-Id` response headers. Async is
+JSON-only — combining it with a text `format` is rejected. `annotation` is the
+task that needs it:
 
 ```python
 import time
@@ -246,19 +295,56 @@ composite:
   — takes a **handle, not a region** (acquire one with `fetch_region` first);
   `description` is required. Finds genes in the sequence and returns an
   expression prediction for each.
-- **REST:** call gene discovery, then loop `expression` per gene (build each
-  TSS-centred 9,198 bp window via the acquisition helpers).
+- **REST:** one call — `POST /v1/workflows/find-genes-and-predict-expression`,
+  body `{sequence, options}` with `sequence` 1,000–500,000 bp and
+  `options.description` (cell type / assay) required; a missing or empty
+  description is a `422 validation_failed`. It annotates, centres a 9,198 bp
+  window on each discovered gene's TSS (padding with `N` up to half the window
+  rather than dropping an edge gene), and returns a prediction per gene.
+  `meta.task_specific_counts` = `{genes_found, genes_predicted, genes_skipped}`
+  with `genes_predicted + genes_skipped == genes_found`; per-gene causes in
+  `data.expression_predictions[].skip_reason`. Above **50,000 bp** it forces
+  async: a synchronous request over that size is `413 sync_too_large` with
+  `error.details = {sequence_length, threshold}` — retry the same body with
+  `Prefer: respond-async`.
 
 ## Errors
 
-| Code | Meaning | Action |
-|---|---|---|
-| 400 | Invalid request / bad sequence | Check the body shape |
-| 401 | Missing/invalid key (REST) | Set `GI_API_KEY`; or use the keyless MCP demo |
-| 413 | Sequence too long | Stay within the task's length bound (≤500,000 bp) |
-| 429 | Rate / concurrency cap | Back off and retry; ask GI to raise your tier |
-| 422 | Validation failed (`validation_failed`) | The most common failure: expression below 9,198 bp, a missing or out-of-range `tss_index`, or a missing `options.description` |
-| 5xx | Server error | Retry; if persistent, contact support |
+| Code | `error.code` | Meaning | Action |
+|---|---|---|---|
+| 400 | `bad_request` | Malformed request | Check the body shape |
+| 401 / 403 | `unauthorized` / `forbidden` | Missing/invalid key (REST) | Set `GI_API_KEY`; or use the keyless MCP demo |
+| 404 | `not_found` | **Unknown task** (`/v1/tasks/bogus/predict`) or unknown job | Check the task name — an unrecognised task is a 404, not a 422 |
+| 413 | `payload_too_large` | Raw request body over **16 MiB** | Split the input — this is the body cap, not the sequence cap |
+| 413 | `sync_too_large` | Composite called synchronously above 50,000 bp | Retry with `Prefer: respond-async` |
+| 415 | `unsupported_format` | Unsupported `format` query value | Use a format the task supports; there is no silent fallback to JSON |
+| 422 | `validation_failed` | The most common failure: sequence **under the task floor or over 500,000 bp**, expression below 9,198 bp, a missing/out-of-range `tss_index`, a missing `options.description`, or **any unknown body or `options` key** | Read the message; fix the body |
+| 429 | `rate_limited` / `too_many_requests` | Rate / concurrency cap | Back off (honour `Retry-After`); ask GI to raise your tier |
+| 5xx | `internal_error` / `service_unavailable` / `model_loading` / `timeout` | Server error | Retry; if persistent, contact support |
+
+`error.code` is a closed 21-value enum (`bad_request`, `unauthorized`,
+`forbidden`, `not_found`, `conflict`, `job_expired`, `payload_too_large`,
+`sync_too_large`, `unsupported_format`, `validation_failed`,
+`too_many_requests`, `rate_limited`, `internal_error`, `timeout`,
+`insufficient_memory`, `model_not_found`, `task_not_supported_by_model`,
+`model_loading`, `service_unavailable`, `http_error`, `unknown`); treat an
+unlisted value as a generic failure, not a parse error.
+
+**Branch on `code`, never on `details` or `loc`.** `details` is documented as
+keyed on the sibling `code`, but a validation failure currently arrives as a bare
+FastAPI error *array* (`[{loc, msg, type}, …]`) rather than the `{errors: […]}`
+object the schema declares — read it defensively and keep control flow off it.
+
+`error.request_id` is always populated and mirrors the `X-Request-Id` header.
+Every response carries `RateLimit-Limit`, `RateLimit-Remaining`,
+`RateLimit-Reset`, `RateLimit-Policy`; a `429` adds `Retry-After`.
+
+> Schema-version note: this describes the contract served from `2026.08.19.4`.
+> `api.genomicintelligence.ai` may still be on `2026.08.18.1` until that build is
+> promoted, where the six literal operations, the typed `options`, the per-task
+> floors, the published composite, the `Prefer` parameter, the `code` enum and the
+> new `bio_spec` fields are not yet present. URLs and envelopes are the same
+> either way — check `info.version` in `/v1/openapi.json`.
 
 ## Reference files
 

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -337,7 +337,9 @@ keyed on the sibling `code`, but a validation failure currently arrives as a bar
 FastAPI error *array* (`[{loc, msg, type}, …]`) rather than the `{errors: […]}`
 object the schema declares — read it defensively and keep control flow off it.
 
-`error.request_id` is always populated and mirrors the `X-Request-Id` header.
+`error.request_id` mirrors the `X-Request-Id` header. The header is set on every
+response; the body field is not — `413 sync_too_large` omits it — so fall back to
+the header.
 Every response carries `RateLimit-Limit`, `RateLimit-Remaining`,
 `RateLimit-Reset`, `RateLimit-Policy`; a `429` adds `Retry-After`.
 

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -4,7 +4,7 @@ description: "Predict regulatory features, gene structure, and expression direct
 license: MIT
 compatibility: Python 3.10+ with the `requests` library for the REST path (no dedicated SDK). Network access required. The REST `/v1` API needs a `GI_API_KEY` (a `gi_` bearer); the hosted MCP server at mcp.genomicintelligence.ai/mcp works keyless against a capped public demo quota, key optional.
 metadata:
-  version: "1.0"
+  version: "1.1"
   skill-author: Genomic Intelligence
   trigger-keywords: DNA sequence prediction, regulatory genomics, promoter prediction, splice site prediction, enhancer activity, chromatin state, gene expression prediction, sequence to expression, log TPM, gene annotation, transcript prediction, DNA language model, genomic intelligence, hosted inference, Ensembl sequence, FASTA prediction, cis-regulatory, TSS window, DeepSEA, DeepSTARR, BigBird splice, MCP genomics
   openclaw:
@@ -332,23 +332,22 @@ composite:
 `model_loading`, `service_unavailable`, `http_error`, `unknown`); treat an
 unlisted value as a generic failure, not a parse error.
 
-**Branch on `code`, never on `details` or `loc`.** `details` is documented as
-keyed on the sibling `code`, but a validation failure currently arrives as a bare
-FastAPI error *array* (`[{loc, msg, type}, …]`) rather than the `{errors: […]}`
-object the schema declares — read it defensively and keep control flow off it.
+**Branch on `code`, never on `details` or `loc`.** `details` is keyed on the
+sibling `code`, and its shape for `validation_failed` has been in flux — some
+deployments return the `{errors: […]}` object the schema declares, others a bare
+FastAPI error array (`[{loc, msg, type}, …]`). Treat it as display-only and
+accept either shape; `code` is the stable discriminator.
 
-`error.request_id` mirrors the `X-Request-Id` header. The header is set on every
-response; the body field is not — `413 sync_too_large` omits it — so fall back to
-the header.
+For correlation, prefer the `X-Request-Id` **header**: it is set on every
+response, whereas `error.request_id` is absent on some error paths (`413`
+historically omitted it). Reading the header first is correct on every
+deployment.
 Every response carries `RateLimit-Limit`, `RateLimit-Remaining`,
 `RateLimit-Reset`, `RateLimit-Policy`; a `429` adds `Retry-After`.
 
-> Schema-version note: this describes the contract served from `2026.08.19.4`.
-> `api.genomicintelligence.ai` may still be on `2026.08.18.1` until that build is
-> promoted, where the six literal operations, the typed `options`, the per-task
-> floors, the published composite, the `Prefer` parameter, the `code` enum and the
-> new `bio_spec` fields are not yet present. URLs and envelopes are the same
-> either way — check `info.version` in `/v1/openapi.json`.
+> This describes the contract served from `2026.08.19.4`, verified live. The API
+> is pre-GA and still moving; `info.version` in `/v1/openapi.json` reports what a
+> given deployment actually serves, and is the arbiter if anything here disagrees.
 
 ## Reference files
 

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -91,14 +91,16 @@ same strings clients already POST to, so no URL construction changes; the shared
 `PredictRequest` schema is gone. Body is `{sequence, sequence_name?, model?,
 options?}`, returning a `{data, meta}` envelope. What differs per task:
 
-| Task | Mode | Accepted length | `context_window_bp` | Notes |
+| Task | Recommended mode | Accepted length | `context_window_bp` | Notes |
 |---|---|---|---|---|
 | `promoter` | sync | 300–500,000 bp | 2,000 bp | sliding-window promoter regions |
 | `splice` | sync | 100–500,000 bp | 15,000 bp | donor/acceptor sites (long-context BigBird); strand-specific — feed transcript orientation |
 | `enhancer` | sync | 50–500,000 bp | 249 bp | dev + housekeeping scores (DeepSTARR, *Drosophila*) |
 | `chromatin` | sync | 200–500,000 bp | 1,000 bp | hundreds of tracks (DeepSEA) |
 | `expression` | sync | **9,198–500,000 bp** | n/a (`trained_window_bp` 9,198) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
-| `annotation` | **async** | 1,000–500,000 bp | n/a | de-novo transcripts; submit + poll |
+| `annotation` | async | 1,000–500,000 bp | n/a | de-novo transcripts; submit + poll |
+
+`Recommended mode` is guidance, not a constraint — every task accepts both. Omit `Prefer` for a synchronous `200`; send `Prefer: respond-async` for a `202` plus `GET /v1/tasks/jobs/{job_id}`. Only the composite workflow enforces a mode, rejecting sync above 50,000 bp with `413 sync_too_large`.
 
 **The minimum is admission control, not regime.** A request above the floor but
 shorter than the selected model's `bio_spec.context_window_bp` is *accepted and

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -164,9 +164,10 @@ or query parameter:
 > a locus start rather than the submitted slice) does not error — it returns a
 > confident `200` for the wrong window. Assert on
 > `meta.task_specific_counts.scored_window` / `.tss_index` in the response.
-> Also note `data.input.sequence_length` is the **scored** length (always
-> 9,198); the length you submitted is `data.input.submitted_sequence_length`
-> (and `meta.sequence_length`).
+> The length you submitted is `meta.sequence_length` (also echoed as
+> `data.input.submitted_sequence_length`); the scored width is always 9,198,
+> i.e. `scored_window[1] - scored_window[0]`. (`data.input.sequence_length`
+> was removed at contract revision 13.)
 >
 > Both `tss_index` violations — "required unless exactly 9,198 bp" and the range
 > check — come from a whole-model validator, so they surface at the body level

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -169,9 +169,11 @@ or query parameter:
 > (and `meta.sequence_length`).
 >
 > Both `tss_index` violations — "required unless exactly 9,198 bp" and the range
-> check — come from a whole-model validator, so they report at `loc: ["body"]`,
-> **never** `body.tss_index`. Match on `error.code == "validation_failed"`; use
-> the message for display only, and never branch on `loc`.
+> check — come from a whole-model validator, so they surface at the body level
+> rather than under `tss_index`. Match on `error.code == "validation_failed"`
+> and use the message for display only. Any `loc` tuple quoted in this skill is
+> illustrative of that shape, not part of the contract: it is not published in
+> the schema and must not be branched on.
 
 ## Sequence acquisition
 
@@ -343,8 +345,10 @@ the header first remains a safe default.
 Every response carries `RateLimit-Limit`, `RateLimit-Remaining`,
 `RateLimit-Reset`, `RateLimit-Policy`; a `429` adds `Retry-After`.
 
-> The contract moves. `info.version` in `/v1/openapi.json` reports what a given
-> deployment serves, and that document is the arbiter if anything here disagrees.
+> Verified against OpenAPI `info.version` **2026.08.20.7**. The contract moves,
+> and `info.version` in `/v1/openapi.json` reports what a given deployment
+> serves: if it is ahead of the version above, re-check the numbers in this file
+> against that document, which is the arbiter if the two disagree.
 
 ## Reference files
 

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -91,13 +91,13 @@ same strings clients already POST to, so no URL construction changes; the shared
 `PredictRequest` schema is gone. Body is `{sequence, sequence_name?, model?,
 options?}`, returning a `{data, meta}` envelope. What differs per task:
 
-| Task | Mode | Accepted length | Model context window | Notes |
+| Task | Mode | Accepted length | `context_window_bp` | Notes |
 |---|---|---|---|---|
 | `promoter` | sync | 300–500,000 bp | 2,000 bp | sliding-window promoter regions |
 | `splice` | sync | 100–500,000 bp | 15,000 bp | donor/acceptor sites (long-context BigBird); strand-specific — feed transcript orientation |
 | `enhancer` | sync | 50–500,000 bp | 249 bp | dev + housekeeping scores (DeepSTARR, *Drosophila*) |
 | `chromatin` | sync | 200–500,000 bp | 1,000 bp | hundreds of tracks (DeepSEA) |
-| `expression` | sync | **9,198–500,000 bp** | 9,198 bp (fixed) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
+| `expression` | sync | **9,198–500,000 bp** | n/a (`trained_window_bp` 9,198) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
 | `annotation` | **async** | 1,000–500,000 bp | n/a | de-novo transcripts; submit + poll |
 
 **The minimum is admission control, not regime.** A request above the floor but

--- a/skills/genomic-intelligence/references/api-and-auth.md
+++ b/skills/genomic-intelligence/references/api-and-auth.md
@@ -90,10 +90,11 @@ length — under the floor *or* over 500,000 bp; over-length is not a `413`).
   against this to know whether the model scored real sequence or padding.
 - `trained_window_bp` — fixed receptive field; 9,198 for `g0-expression`, `null`
   for sliding-window models.
-- `max_seq_length_bp` — legacy, ambiguous, and being withdrawn. It reads 500,000
-  everywhere **except** `g0-expression`, where it is 9,198 — the trained window,
-  not a request cap, so reading it as one wrongly rejects the 9,198–500,000 bp
-  range expression actually accepts. Never gate on it; use `request_max_bp`.
+- The legacy `max_seq_length_bp` was retired from `bio_spec` in gpu_service
+  `2026.08.19.5` and is absent from the live response. It was ambiguous — it read
+  9,198 for `g0-expression`, the trained window rather than a request cap, so
+  gating on it wrongly rejected the 9,198–500,000 bp range expression accepts.
+  Use `request_max_bp`.
 
 There is no `strand_sensitive` flag. The splice model is strand-specific in
 practice — feed transcript orientation.

--- a/skills/genomic-intelligence/references/api-and-auth.md
+++ b/skills/genomic-intelligence/references/api-and-auth.md
@@ -23,25 +23,68 @@ commit it.
 
 ## Endpoints
 
+Eleven operations are published. The six predict paths are **literal, one per
+task** — the templated `/v1/tasks/{task}/predict` is no longer in the document
+(the URLs are unchanged, so nothing a client builds needs to change).
+
 | Method | Path | Purpose |
 |---|---|---|
-| POST | `/v1/tasks/{task}/predict` | Run a task (sync, or async for `annotation` with `Prefer: respond-async`). `task` ∈ promoter, splice, enhancer, chromatin, annotation |
-| POST | `/v1/tasks/expression/predict` | Expression — same URL shape, but its own published operation and its own (stricter) request schema |
+| POST | `/v1/tasks/promoter/predict` | `PromoterPredictRequest` |
+| POST | `/v1/tasks/splice/predict` | `SplicePredictRequest` |
+| POST | `/v1/tasks/enhancer/predict` | `EnhancerPredictRequest` |
+| POST | `/v1/tasks/chromatin/predict` | `ChromatinPredictRequest` |
+| POST | `/v1/tasks/annotation/predict` | `AnnotationPredictRequest` |
+| POST | `/v1/tasks/expression/predict` | `ExpressionPredictRequest` (also requires `options`) |
+| POST | `/v1/workflows/find-genes-and-predict-expression` | Composite: find genes, predict each one's expression |
+| GET | `/v1/tasks/jobs` | List async jobs |
 | GET | `/v1/tasks/jobs/{job_id}` | Poll an async job (202 running → 200 terminal) |
 | GET | `/v1/tasks/{task}/models` | List available model IDs for a task |
+| GET | `/health` | Public liveness |
+
+`Prefer: respond-async` is a declared header parameter on all six predict
+operations and on the composite. An unrecognised task segment is
+`404 not_found` (`"Unknown task: bogus"`), **not** a `422`.
 
 ## Request / response
 
-Request body: `{sequence, sequence_name, model?, options?}`. `options` is
-task-specific. **`expression` differs**: its body is
-`{sequence, options, tss_index?, sequence_name?, model?}`, is closed to unknown
-fields, requires `options.description` (the only key it accepts), and requires
-`tss_index` unless `sequence` is exactly 9,198 bp. See `tasks.md#expression`.
+Request body: `{sequence, sequence_name?, model?, options?}` — but there is no
+longer a shared `PredictRequest`. Each task has its own request model with its own
+`minLength` (promoter 300, splice 100, enhancer 50, chromatin 200, annotation
+1,000, expression 9,198, composite 1,000; `maxLength` 500,000 for all), and every
+one is `additionalProperties: false`. `options` is likewise typed and closed per
+task, so an unknown key is `422 validation_failed` with `type: "extra_forbidden"`
+at `loc ["body","options","<key>"]`.
+
+**`expression` differs further**: its body is
+`{sequence, options, tss_index?, sequence_name?, model?}`, `options` is required
+(`ExpressionOptions.required = ["description"]`, the only key it accepts), and
+`tss_index` is required unless `sequence` is exactly 9,198 bp. See
+`tasks.md#expression`.
 
 Success is a `{data, meta}` envelope; `data` is task-specific (see `tasks.md`),
-`meta` carries model + request info. Errors use an `{error}` envelope carrying
-`code`, `message`, `status` and `request_id`; the most common is `422`
-`validation_failed` (wrong sequence length).
+`meta` carries model + request info. **Exception:** `GET /v1/tasks/{task}/models`
+is *not* enveloped — it returns a flat
+`{task, default_model, models: [{id, name, description, is_default, bio_spec}]}`.
+
+Errors use an `{error}` envelope carrying `code`, `message`, `request_id` and an
+optional `details`; the most common is `422 validation_failed` (wrong sequence
+length — under the floor *or* over 500,000 bp; over-length is not a `413`).
+
+## `bio_spec` (from `GET /v1/tasks/{task}/models`)
+
+- `request_max_bp` — the enforced ceiling: 500,000 for every model.
+- `context_window_bp` — the model's own sliding window; `null` for annotation and
+  expression. Live: promoter `g0-promoter-2000bp` 2,000 (300 bp promoter models
+  300), splice 15,000, enhancer 249, chromatin 1,000. Compare your sequence length
+  against this to know whether the model scored real sequence or padding.
+- `trained_window_bp` — fixed receptive field; 9,198 for `g0-expression`, `null`
+  for sliding-window models.
+- `max_seq_length_bp` — legacy and ambiguous: 500,000 everywhere **except**
+  `g0-expression`, where it is 9,198 (the trained window, not a cap). Prefer
+  `request_max_bp`.
+
+There is no `strand_sensitive` flag. The splice model is strand-specific in
+practice — feed transcript orientation.
 
 ## Partner tiers
 

--- a/skills/genomic-intelligence/references/api-and-auth.md
+++ b/skills/genomic-intelligence/references/api-and-auth.md
@@ -18,14 +18,15 @@ key from the environment (or a `.env` via `python-dotenv`); never hardcode or
 commit it.
 
 > The hosted **MCP** server (`mcp.genomicintelligence.ai/mcp`) is different: it
-> runs **keyless** against a capped public demo quota, with the key optional for
-> a higher quota. Only the **REST** path strictly requires a key. See `mcp.md`.
+> runs **keyless** against a rate- and concurrency-limited public demo tier, with
+> the key optional for higher limits. Only the **REST** path strictly requires a
+> key. See `mcp.md`.
 
 ## Endpoints
 
 Eleven operations are published. The six predict paths are **literal, one per
-task** — the templated `/v1/tasks/{task}/predict` is no longer in the document
-(the URLs are unchanged, so nothing a client builds needs to change).
+task**; the published document has no templated `/v1/tasks/{task}/predict`
+operation.
 
 | Method | Path | Purpose |
 |---|---|---|
@@ -68,9 +69,9 @@ at `loc ["body","options","<key>"]`.
 `tss_index` is required unless `sequence` is exactly 9,198 bp. See
 `tasks.md#expression`.
 
-Hand-built requests are unaffected, but a client **generated** from the OpenAPI
-document must be regenerated: the shared `PredictRequest` model it was built
-from no longer exists.
+Hand-built requests are unaffected. A client **generated** from an older OpenAPI
+document must be regenerated against the current one: the shared `PredictRequest`
+model such clients were built from is not in the published document.
 
 Success is a `{data, meta}` envelope; `data` is task-specific (see `tasks.md`),
 `meta` carries model + request info. **Exception:** `GET /v1/tasks/{task}/models`
@@ -85,16 +86,15 @@ length — under the floor *or* over 500,000 bp; over-length is not a `413`).
 
 - `request_max_bp` — the enforced ceiling: 500,000 for every model.
 - `context_window_bp` — the model's own sliding window; `null` for annotation and
-  expression. Live: promoter `g0-promoter-2000bp` 2,000 (300 bp promoter models
-  300), splice 15,000, enhancer 249, chromatin 1,000. Compare your sequence length
-  against this to know whether the model scored real sequence or padding.
-- `trained_window_bp` — fixed receptive field; 9,198 for `g0-expression`, `null`
-  for sliding-window models.
-- The legacy `max_seq_length_bp` was retired from `bio_spec` in gpu_service
-  `2026.08.19.5` and is absent from the live response. It was ambiguous — it read
-  9,198 for `g0-expression`, the trained window rather than a request cap, so
-  gating on it wrongly rejected the 9,198–500,000 bp range expression accepts.
-  Use `request_max_bp`.
+  expression. The promoter default reports 2,000 (the 300 bp promoter models
+  report 300), splice 15,000, enhancer 249, chromatin 1,000. Compare your sequence
+  length against this to know whether the model scored real sequence or padding.
+- `trained_window_bp` — fixed receptive field; 9,198 for the expression model,
+  `null` for sliding-window models.
+- The legacy `max_seq_length_bp` is not part of `bio_spec` and is absent from the
+  response. It was ambiguous — it read 9,198 for the expression model, the trained
+  window rather than a request cap, so gating on it wrongly rejected the
+  9,198–500,000 bp range expression accepts. Use `request_max_bp`.
 
 There is no `strand_sensitive` flag. The splice model is strand-specific in
 practice — feed transcript orientation.

--- a/skills/genomic-intelligence/references/api-and-auth.md
+++ b/skills/genomic-intelligence/references/api-and-auth.md
@@ -41,9 +41,16 @@ task** — the templated `/v1/tasks/{task}/predict` is no longer in the document
 | GET | `/v1/tasks/{task}/models` | List available model IDs for a task |
 | GET | `/health` | Public liveness |
 
+There is no usable templated route to fall back on: the six literal paths are
+matched first, and any other task segment is `404 not_found`
+(`"Unknown task: bogus"`), never a `422`.
+
 `Prefer: respond-async` is a declared header parameter on all six predict
-operations and on the composite. An unrecognised task segment is
-`404 not_found` (`"Unknown task: bogus"`), **not** a `422`.
+operations and on the composite — it is not an annotation-only extra. Omit it
+for a synchronous `200`; send it for a `202` carrying
+`{data: {job_id, status: "accepted", links}, meta}`, with the id also in
+`Content-Location` and `X-Job-Id`, then poll `GET /v1/tasks/jobs/{job_id}`.
+Async is JSON-only: combining it with a text `format` is a `400`.
 
 ## Request / response
 
@@ -60,6 +67,10 @@ at `loc ["body","options","<key>"]`.
 (`ExpressionOptions.required = ["description"]`, the only key it accepts), and
 `tss_index` is required unless `sequence` is exactly 9,198 bp. See
 `tasks.md#expression`.
+
+Hand-built requests are unaffected, but a client **generated** from the OpenAPI
+document must be regenerated: the shared `PredictRequest` model it was built
+from no longer exists.
 
 Success is a `{data, meta}` envelope; `data` is task-specific (see `tasks.md`),
 `meta` carries model + request info. **Exception:** `GET /v1/tasks/{task}/models`
@@ -79,9 +90,10 @@ length — under the floor *or* over 500,000 bp; over-length is not a `413`).
   against this to know whether the model scored real sequence or padding.
 - `trained_window_bp` — fixed receptive field; 9,198 for `g0-expression`, `null`
   for sliding-window models.
-- `max_seq_length_bp` — legacy and ambiguous: 500,000 everywhere **except**
-  `g0-expression`, where it is 9,198 (the trained window, not a cap). Prefer
-  `request_max_bp`.
+- `max_seq_length_bp` — legacy, ambiguous, and being withdrawn. It reads 500,000
+  everywhere **except** `g0-expression`, where it is 9,198 — the trained window,
+  not a request cap, so reading it as one wrongly rejects the 9,198–500,000 bp
+  range expression actually accepts. Never gate on it; use `request_max_bp`.
 
 There is no `strand_sensitive` flag. The splice model is strand-specific in
 practice — feed transcript orientation.

--- a/skills/genomic-intelligence/references/api-and-auth.md
+++ b/skills/genomic-intelligence/references/api-and-auth.md
@@ -25,14 +25,18 @@ commit it.
 
 | Method | Path | Purpose |
 |---|---|---|
-| POST | `/v1/tasks/{task}/predict` | Run a task (sync, or async for `annotation` with `Prefer: respond-async`) |
+| POST | `/v1/tasks/{task}/predict` | Run a task (sync, or async for `annotation` with `Prefer: respond-async`). `task` ∈ promoter, splice, enhancer, chromatin, annotation |
+| POST | `/v1/tasks/expression/predict` | Expression — same URL shape, but its own published operation and its own (stricter) request schema |
 | GET | `/v1/tasks/jobs/{job_id}` | Poll an async job (202 running → 200 terminal) |
 | GET | `/v1/tasks/{task}/models` | List available model IDs for a task |
 
 ## Request / response
 
 Request body: `{sequence, sequence_name, model?, options?}`. `options` is
-task-specific — most notably `options.description` (required for `expression`).
+task-specific. **`expression` differs**: its body is
+`{sequence, options, tss_index?, sequence_name?, model?}`, is closed to unknown
+fields, requires `options.description` (the only key it accepts), and requires
+`tss_index` unless `sequence` is exactly 9,198 bp. See `tasks.md#expression`.
 
 Success is a `{data, meta}` envelope; `data` is task-specific (see `tasks.md`),
 `meta` carries model + request info. Errors use an `{error}` envelope carrying

--- a/skills/genomic-intelligence/references/mcp.md
+++ b/skills/genomic-intelligence/references/mcp.md
@@ -6,8 +6,8 @@ GI hosts a Model Context Protocol server (Streamable HTTP) at:
 https://mcp.genomicintelligence.ai/mcp
 ```
 
-It works **keyless** against a capped public demo quota, with no setup. An
-optional `gi_` bearer key (`GI_API_KEY`) raises the quota. Prefer MCP on agent
+It works **keyless** against a rate- and concurrency-limited public demo tier,
+with no setup. An optional `gi_` bearer key (`GI_API_KEY`) raises those limits. Prefer MCP on agent
 hosts that support it: the tools use agent-friendly, handle-based schemas so large
 sequences never enter the context.
 

--- a/skills/genomic-intelligence/references/sequence-acquisition.md
+++ b/skills/genomic-intelligence/references/sequence-acquisition.md
@@ -59,6 +59,10 @@ reference sequence for the requested coordinates.
 
 ## Limits
 
-Bounded by the task's own cap (500,000 bp for every task; expression additionally
-has a 9,198 bp **floor**). Ensembl enforces its own per-request size limits; fetch very large
+Bounded by the task's own cap (500,000 bp for every task) and its **floor**:
+promoter 300, splice 100, enhancer 50, chromatin 200, annotation 1,000,
+expression 9,198 bp. Clearing the floor only gets the request accepted — fetch at
+least the model's `context_window_bp` (promoter 2,000, splice 15,000, enhancer
+249, chromatin 1,000) if you want the score to reflect real sequence rather than
+padding. Ensembl enforces its own per-request size limits; fetch very large
 ranges in pieces.

--- a/skills/genomic-intelligence/references/sequence-acquisition.md
+++ b/skills/genomic-intelligence/references/sequence-acquisition.md
@@ -13,12 +13,18 @@ Over REST, query Ensembl yourself, then feed the sequence to `/v1/tasks/...`.
 - **Full gene body** (any task except expression) — resolve the gene, fetch its
   sequence.
 - **Coordinate range** — fetch `/sequence/region/{species}/{region}`.
-- **Exact 9,198 bp TSS-centred window** (expression only) — see below.
+- **9,198 bp TSS-centred window, or a wider locus + a `tss_index`** (expression
+  only) — see below.
 
 ## TSS-centring (why expression is special)
 
-The expression model requires **exactly 9,198 bp centred on the transcription
-start site (TSS)**. You cannot reliably build this from gene-body coordinates:
+The expression model always scores **exactly 9,198 bp centred on the
+transcription start site (TSS)**. You can either hand it a pre-cut 9,198 bp
+window, or hand it up to 500,000 bp plus `tss_index` — the 0-based TSS offset
+into the whitespace-stripped sequence — and let the server slice
+`sequence[tss_index-4599 : tss_index+4599]`. Either way you must know where the
+TSS is; the endpoint never discovers it, never pads, and never
+reverse-complements. You cannot reliably build this from gene-body coordinates:
 the annotated gene start/end can sit far from the real TSS (HBB's gene end is
 2,324 bp from its canonical TSS; ACTB's is 33,301 bp). Mis-centring tanks the
 prediction.
@@ -29,6 +35,12 @@ strand), and take **4,599 bp upstream + 4,598 bp downstream on the gene's
 strand = 9,198 bp**; validate the length exactly. On MCP,
 `fetch_gene_for_expression(gene=...)` does all of this. Because it needs a
 transcript, it works from a **gene**, not a bare region.
+
+If instead you submit a wider locus with `tss_index`, the offset must be counted
+on the **stripped nucleotide string** (no newlines, no FASTA header) and satisfy
+`4599 ≤ tss_index ≤ len(sequence) − 4599`. An offset that is out of range 422s;
+one that is merely *wrong* but in range silently scores the wrong window, so
+check `meta.task_specific_counts.scored_window` on the response.
 
 ## Species & assembly
 
@@ -47,6 +59,6 @@ reference sequence for the requested coordinates.
 
 ## Limits
 
-Bounded by the task's own cap (500,000 bp for most; exactly 9,198 bp for
-expression). Ensembl enforces its own per-request size limits; fetch very large
+Bounded by the task's own cap (500,000 bp for every task; expression additionally
+has a 9,198 bp **floor**). Ensembl enforces its own per-request size limits; fetch very large
 ranges in pieces.

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -123,8 +123,8 @@ Result: `data.prediction.expression_log_tpm` (and `expression_tpm`).
 `meta.task_specific_counts` carries `tss_index` and `scored_window`
 (`[start, end]`, always 9,198 wide) — assert on it, because an in-range but
 wrong `tss_index` scores the wrong window with a `200`. `data.input` echoes
-`tss_index`, `scored_window`, and `submitted_sequence_length`; note
-`data.input.sequence_length` is the **scored** 9,198, not what you submitted.
+`tss_index`, `scored_window`, and `submitted_sequence_length`; the length you
+submitted is `meta.sequence_length`, and the scored width is always 9,198.
 
 Both `tss_index` failures come from a whole-model validator and so report at
 `loc: ["body"]`, **never** `body.tss_index`. Match on

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -5,10 +5,9 @@ Six DNA-sequence tasks, each its own published REST operation —
 `/v1/tasks/enhancer/predict`, `/v1/tasks/chromatin/predict`,
 `/v1/tasks/annotation/predict`, `/v1/tasks/expression/predict` — with body
 `{sequence, sequence_name?, model?, options?}`, returning a `{data, meta}`
-envelope. The URLs are the same strings clients already send; what changed is that
-each has its own request schema, its own `minLength`, and its own closed `options`
-object (there is no shared `PredictRequest` any more). On MCP, the equivalent is
-`predict_<task>(sequence_ref, ...)`.
+envelope. Each path is a literal string, and each carries its own request schema,
+its own `minLength`, and its own closed `options` object; there is no shared
+`PredictRequest`. On MCP, the equivalent is `predict_<task>(sequence_ref, ...)`.
 
 **Omit `model` to get the task's default** — the API resolves it server-side
 (`model` is optional: *"If omitted, the task's default model is used."*). Default
@@ -37,10 +36,10 @@ strictest its models need, and every model stays listed and loadable.
 
 **Floor ≠ regime.** A request above the floor but shorter than the selected
 model's `bio_spec.context_window_bp` is accepted and scored — against a window
-padded out to the context window. Enhancer is the sharp case: the bound is 50 bp
-(DeepSTARR's admission gate; `dnabert-deepstarr` tolerates 16) while the context
-window is 249 bp, so 50–248 bp is scored mostly on padding. Compare your length
-against `context_window_bp` to know whether the model saw real sequence.
+padded out to the context window. Enhancer is the sharp case: the floor is 50 bp
+while the context window is 249 bp, so 50–248 bp is scored mostly on padding.
+Compare your length against `context_window_bp` to know whether the model saw
+real sequence.
 Longer-than-context input is fine — the scanner steps a prediction window at a
 time and pads only the final partial window.
 
@@ -127,14 +126,15 @@ wrong `tss_index` scores the wrong window with a `200`. `data.input` echoes
 `tss_index`, `scored_window`, and `submitted_sequence_length`; note
 `data.input.sequence_length` is the **scored** 9,198, not what you submitted.
 
-Both `tss_index` failures come from a `model_validator(mode="after")` and so
-report at `loc: ["body"]`, **never** `body.tss_index`. Match on
+Both `tss_index` failures come from a whole-model validator and so report at
+`loc: ["body"]`, **never** `body.tss_index`. Match on
 `error.code == "validation_failed"` — never on `loc`.
 
 ## annotation
 De-novo gene / transcript structure — transcript intervals and strand, no
 reference annotation. **Run it async** (`Prefer: respond-async` is available on
-every predict operation; annotation is the one that needs it): submit with
+every predict operation; annotation is the one that most often needs it):
+submit with
 `Prefer: respond-async` → `job_id`; poll `GET /v1/tasks/jobs/{job_id}` until it
 returns `200`. `data.transcripts` lists each transcript with `name`, `start`,
 `end`, `strand`, `score`, plus structure fields (`length`, `tss_position`,

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -20,13 +20,13 @@ with `GET /v1/tasks/{task}/models` (REST) or `list_models(task)` (MCP), and
 Source of truth for bounds: the live OpenAPI at
 <https://api.genomicintelligence.ai/v1/openapi.json>.
 
-| Task | Mode | Accepted length | Model context window | Default architecture |
+| Task | Mode | Accepted length | `context_window_bp` | Default architecture |
 |---|---|---|---|---|
 | promoter | sync | 300–500,000 bp | 2,000 bp | sliding-window; human/mammalian |
 | splice | sync | 100–500,000 bp | 15,000 bp | BigBird (long-context) |
 | enhancer | sync | 50–500,000 bp | 249 bp | DeepSTARR — ***Drosophila*** |
 | chromatin | sync | 200–500,000 bp | 1,000 bp | DeepSEA — hundreds of tracks |
-| expression | sync | **9,198–500,000 bp** (scores one 9,198 bp window) | 9,198 bp (fixed) | log(TPM+1) |
+| expression | sync | **9,198–500,000 bp** (scores one 9,198 bp window) | n/a (`trained_window_bp` 9,198) | log(TPM+1) |
 | annotation | **async** | 1,000–500,000 bp | n/a | de-novo transcripts |
 
 The minimum is published as `minLength` on each task's request schema and enforced

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -20,14 +20,16 @@ with `GET /v1/tasks/{task}/models` (REST) or `list_models(task)` (MCP), and
 Source of truth for bounds: the live OpenAPI at
 <https://api.genomicintelligence.ai/v1/openapi.json>.
 
-| Task | Mode | Accepted length | `context_window_bp` | Default architecture |
+| Task | Recommended mode | Accepted length | `context_window_bp` | Default architecture |
 |---|---|---|---|---|
 | promoter | sync | 300–500,000 bp | 2,000 bp | sliding-window; human/mammalian |
 | splice | sync | 100–500,000 bp | 15,000 bp | BigBird (long-context) |
 | enhancer | sync | 50–500,000 bp | 249 bp | DeepSTARR — ***Drosophila*** |
 | chromatin | sync | 200–500,000 bp | 1,000 bp | DeepSEA — hundreds of tracks |
 | expression | sync | **9,198–500,000 bp** (scores one 9,198 bp window) | n/a (`trained_window_bp` 9,198) | log(TPM+1) |
-| annotation | **async** | 1,000–500,000 bp | n/a | de-novo transcripts |
+| annotation | async | 1,000–500,000 bp | n/a | de-novo transcripts |
+
+`Recommended mode` is guidance, not a constraint — every task accepts both. Omit `Prefer` for a synchronous `200`; send `Prefer: respond-async` for a `202` plus `GET /v1/tasks/jobs/{job_id}`. Only the composite workflow enforces a mode, rejecting sync above 50,000 bp with `413 sync_too_large`.
 
 The minimum is published as `minLength` on each task's request schema and enforced
 before any model loads. There are **no per-model floors**: a task's floor is the

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -20,7 +20,7 @@ Source of truth for bounds: the live OpenAPI at
 | splice | sync | 1–500,000 bp | BigBird (long-context) |
 | enhancer | sync | 1–500,000 bp | DeepSTARR — ***Drosophila*** |
 | chromatin | sync | 1–500,000 bp | DeepSEA — hundreds of tracks |
-| expression | sync | **exactly 9,198 bp** | log(TPM+1) |
+| expression | sync | **9,198–500,000 bp** (scores one 9,198 bp window) | log(TPM+1) |
 | annotation | **async** | 1–500,000 bp | de-novo transcripts |
 
 ## promoter
@@ -46,17 +46,36 @@ binding). The default (DeepSEA) covers hundreds of features.
 `data`.
 
 ## expression
-Expression as **log(TPM+1)** from a fixed window. Two enforced requirements:
+Expression as **log(TPM+1)** from a fixed window. Since 2026-08-18 this task has
+its own published OpenAPI operation (`POST /v1/tasks/expression/predict`,
+schema `ExpressionPredictRequest`) rather than the generic
+`/v1/tasks/{task}/predict` body — codegen consumers must regenerate. Body:
+`{sequence, options, tss_index?, sequence_name?, model?}`, closed to unknown
+fields. Three enforced requirements, each a `422` when violated:
 
-1. **Exactly 9,198 bp** — a window **centred on the TSS** (4,599 upstream +
-   TSS + 4,598 downstream). Other
-   lengths are rejected. Build it with the acquisition helpers
-   (`fetch_gene_for_expression` on MCP), not by hand — see
-   `sequence-acquisition.md`.
-2. **`options.description`** — a cell-type / assay string (e.g. `"K562 cells"`).
-   Required.
+1. **9,198–500,000 bp.** The model scores exactly one 9,198 bp window
+   **centred on the TSS** — `sequence[tss_index-4599 : tss_index+4599]` — but
+   the endpoint accepts up to 500 kb and slices for you. Below 9,198 bp is
+   rejected; nothing is padded or truncated.
+2. **`tss_index`** — 0-based TSS offset into the **whitespace-stripped**
+   sequence. Required unless the sequence is exactly 9,198 bp (where it defaults
+   to 4,599, the only legal value). Bounds:
+   `4599 ≤ tss_index ≤ len(sequence) − 4599`. The server does not find the TSS
+   for you and does not reverse-complement — submit gene-sense.
+3. **`options.description`** — a cell-type / assay string (e.g. `"K562 cells"`).
+   Required, and the only key `options` accepts here.
+
+Whitespace is stripped before lengths and `tss_index` are interpreted, so a
+line-wrapped FASTA *body* can be pasted verbatim — but a `>` header line cannot
+(it fails the A/C/G/T/N alphabet check), and offsets must be counted on the
+stripped string, not on file characters.
 
 Result: `data.prediction.expression_log_tpm` (and `expression_tpm`).
+`meta.task_specific_counts` carries `tss_index` and `scored_window`
+(`[start, end]`, always 9,198 wide) — assert on it, because an in-range but
+wrong `tss_index` scores the wrong window with a `200`. `data.input` echoes
+`tss_index`, `scored_window`, and `submitted_sequence_length`; note
+`data.input.sequence_length` is the **scored** 9,198, not what you submitted.
 
 ## annotation
 De-novo gene / transcript structure — transcript intervals and strand, no
@@ -71,5 +90,7 @@ returns `200`. `data.transcripts` lists each transcript with `name`, `start`,
 `find_genes_and_predict_expression(sequence_ref, description)` takes a **handle,
 not a region** (acquire one with `fetch_region` first); `description` is
 required. It finds genes in the sequence
-and returns an expression prediction per gene. Over REST, discover genes then
-loop `expression` per gene (build each TSS-centred 9,198 bp window first).
+and returns an expression prediction per gene. The composite does its own gene
+finding and windowing, so it has **no** 9,198 bp floor and takes **no**
+`tss_index`. Over REST, discover genes then loop `expression` per gene (build
+each TSS-centred 9,198 bp window, or pass the locus plus a `tss_index`).

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -77,6 +77,14 @@ Splice **donor** and **acceptor** sites. `data.sites` lists each with `name`,
 `start`, `end`, `site_type` (donor/acceptor), `score`, `strand`. The default is a
 BigBird long-context model.
 
+**Strand-specific — and the wrong strand fails silently.** Submit transcript
+orientation (reverse-complement minus-strand genes). A reverse-complemented
+sequence does *not* return zeros or an empty result: measured live, it returns
+plausible sites at different positions, often still at high confidence, and site
+counts can hold or collapse depending on the locus. **Neither the score nor the
+count tells you the orientation was wrong**, so there is no post-hoc check —
+get the orientation right on input.
+
 ## enhancer
 Enhancer activity. The default (DeepSTARR) reports **developmental**
 and **housekeeping** scores — `summary.dev_score_max` / `summary.hk_score_max`
@@ -159,4 +167,10 @@ refuses to pad at all. `meta.task_specific_counts` =
 
 Above **50,000 bp** it forces async: a synchronous request over that size is
 `413 sync_too_large` with `error.details = {sequence_length, threshold}`. Retry
-the same body with `Prefer: respond-async`.
+the same body with `Prefer: respond-async`. This is the only endpoint that
+forces a delivery mode.
+
+The equivalent by hand is `annotation` to discover genes, then one `expression`
+call per gene with that gene's window and `tss_index` — useful when you want
+per-gene control, though you then own the TSS-centring the composite does for
+you.

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -1,8 +1,14 @@
 # Tasks Reference
 
-Six DNA-sequence tasks, one shared REST shape: `POST /v1/tasks/{task}/predict`
-with body `{sequence, sequence_name, model?, options?}`, returning a
-`{data, meta}` envelope. On MCP, the equivalent is `predict_<task>(sequence_ref, ...)`.
+Six DNA-sequence tasks, each its own published REST operation —
+`POST /v1/tasks/promoter/predict`, `/v1/tasks/splice/predict`,
+`/v1/tasks/enhancer/predict`, `/v1/tasks/chromatin/predict`,
+`/v1/tasks/annotation/predict`, `/v1/tasks/expression/predict` — with body
+`{sequence, sequence_name?, model?, options?}`, returning a `{data, meta}`
+envelope. The URLs are the same strings clients already send; what changed is that
+each has its own request schema, its own `minLength`, and its own closed `options`
+object (there is no shared `PredictRequest` any more). On MCP, the equivalent is
+`predict_<task>(sequence_ref, ...)`.
 
 **Omit `model` to get the task's default** — the API resolves it server-side
 (`model` is optional: *"If omitted, the task's default model is used."*). Default
@@ -14,14 +20,49 @@ with `GET /v1/tasks/{task}/models` (REST) or `list_models(task)` (MCP), and
 Source of truth for bounds: the live OpenAPI at
 <https://api.genomicintelligence.ai/v1/openapi.json>.
 
-| Task | Mode | Length | Default architecture |
-|---|---|---|---|
-| promoter | sync | 1–500,000 bp | sliding-window; human/mammalian |
-| splice | sync | 1–500,000 bp | BigBird (long-context) |
-| enhancer | sync | 1–500,000 bp | DeepSTARR — ***Drosophila*** |
-| chromatin | sync | 1–500,000 bp | DeepSEA — hundreds of tracks |
-| expression | sync | **9,198–500,000 bp** (scores one 9,198 bp window) | log(TPM+1) |
-| annotation | **async** | 1–500,000 bp | de-novo transcripts |
+| Task | Mode | Accepted length | Model context window | Default architecture |
+|---|---|---|---|---|
+| promoter | sync | 300–500,000 bp | 2,000 bp | sliding-window; human/mammalian |
+| splice | sync | 100–500,000 bp | 15,000 bp | BigBird (long-context) |
+| enhancer | sync | 50–500,000 bp | 249 bp | DeepSTARR — ***Drosophila*** |
+| chromatin | sync | 200–500,000 bp | 1,000 bp | DeepSEA — hundreds of tracks |
+| expression | sync | **9,198–500,000 bp** (scores one 9,198 bp window) | 9,198 bp (fixed) | log(TPM+1) |
+| annotation | **async** | 1,000–500,000 bp | n/a | de-novo transcripts |
+
+The minimum is published as `minLength` on each task's request schema and enforced
+before any model loads. There are **no per-model floors**: a task's floor is the
+strictest its models need, and every model stays listed and loadable.
+
+**Floor ≠ regime.** A request above the floor but shorter than the selected
+model's `bio_spec.context_window_bp` is accepted and scored — against a window
+padded out to the context window. Enhancer is the sharp case: the bound is 50 bp
+(DeepSTARR's admission gate; `dnabert-deepstarr` tolerates 16) while the context
+window is 249 bp, so 50–248 bp is scored mostly on padding. Compare your length
+against `context_window_bp` to know whether the model saw real sequence.
+Longer-than-context input is fine — the scanner steps a prediction window at a
+time and pads only the final partial window.
+
+Under the floor and over the cap are both `422 validation_failed` at
+`loc ["body","sequence"]`; over-length is **not** a `413`. All lengths are
+measured after whitespace is stripped.
+
+`options` is typed and closed (`additionalProperties: false`) per task — an
+unknown key is a hard `422` (`type: "extra_forbidden"`), never ignored:
+
+| Task | `options` keys |
+|---|---|
+| promoter | `threshold` (0–1, default 0.5) |
+| splice | `threshold` (0–1, default 0.5), `site_types` (subset of `["donor","acceptor"]`, default both) |
+| enhancer | *(none)* |
+| chromatin | `threshold` (0–1, default 0.5) |
+| annotation | `batch_size` (1–128, default 8), `shift_coordinates`, `reverse_complement` (default true) |
+| expression | `description` — **required**, and the only key |
+| composite | `description`, `annotation_model`, `expression_model`, `batch_size`, `shift_coordinates` |
+
+Per-task output `format` values (an unsupported one is `415 unsupported_format`,
+never a silent fallback to JSON; text formats are synchronous-only): promoter
+`json|bed|bedgraph`, splice `json|bed|gff3`, enhancer `json|bedgraph`, chromatin
+`json|bed`, annotation `json|bed|gff3`, expression JSON only.
 
 ## promoter
 Promoter regions over a sliding window. `data.summary` reports
@@ -46,10 +87,9 @@ binding). The default (DeepSEA) covers hundreds of features.
 `data`.
 
 ## expression
-Expression as **log(TPM+1)** from a fixed window. Since 2026-08-18 this task has
-its own published OpenAPI operation (`POST /v1/tasks/expression/predict`,
-schema `ExpressionPredictRequest`) rather than the generic
-`/v1/tasks/{task}/predict` body — codegen consumers must regenerate. Body:
+Expression as **log(TPM+1)** from a fixed window. Its operation is
+`POST /v1/tasks/expression/predict`, schema `ExpressionPredictRequest` — alone
+among the six it requires `options` as well as `sequence`. Body:
 `{sequence, options, tss_index?, sequence_name?, model?}`, closed to unknown
 fields. Three enforced requirements, each a `422` when violated:
 
@@ -77,9 +117,14 @@ wrong `tss_index` scores the wrong window with a `200`. `data.input` echoes
 `tss_index`, `scored_window`, and `submitted_sequence_length`; note
 `data.input.sequence_length` is the **scored** 9,198, not what you submitted.
 
+Both `tss_index` failures come from a `model_validator(mode="after")` and so
+report at `loc: ["body"]`, **never** `body.tss_index`. Match on
+`error.code == "validation_failed"` — never on `loc`.
+
 ## annotation
 De-novo gene / transcript structure — transcript intervals and strand, no
-reference annotation. **Async only**: submit with
+reference annotation. **Run it async** (`Prefer: respond-async` is available on
+every predict operation; annotation is the one that needs it): submit with
 `Prefer: respond-async` → `job_id`; poll `GET /v1/tasks/jobs/{job_id}` until it
 returns `200`. `data.transcripts` lists each transcript with `name`, `start`,
 `end`, `strand`, `score`, plus structure fields (`length`, `tss_position`,
@@ -92,5 +137,24 @@ not a region** (acquire one with `fetch_region` first); `description` is
 required. It finds genes in the sequence
 and returns an expression prediction per gene. The composite does its own gene
 finding and windowing, so it has **no** 9,198 bp floor and takes **no**
-`tss_index`. Over REST, discover genes then loop `expression` per gene (build
-each TSS-centred 9,198 bp window, or pass the locus plus a `tss_index`).
+`tss_index`.
+
+Over REST it is a single published operation:
+`POST /v1/workflows/find-genes-and-predict-expression`, request
+`FindGenesAndPredictExpressionRequest` — `sequence` 1,000–500,000 bp and
+`options` both required, and `options.description` required too (enforced at
+runtime rather than marked `required` in `FindGenesAndPredictExpressionOptions`,
+so a missing or empty value is `422 validation_failed`, *"options.description is
+required (cell type / assay context)"*). Optional: `annotation_model`,
+`expression_model`, `batch_size` (1–128, default 8), `shift_coordinates`.
+
+It cuts a TSS-centred 9,198 bp window per discovered gene, padding with `N` up to
+half the window rather than dropping an edge gene — the direct expression route
+refuses to pad at all. `meta.task_specific_counts` =
+`{genes_found, genes_predicted, genes_skipped}` with
+`genes_predicted + genes_skipped == genes_found`; per-gene causes in
+`data.expression_predictions[].skip_reason`.
+
+Above **50,000 bp** it forces async: a synchronous request over that size is
+`413 sync_too_large` with `error.details = {sequence_length, threshold}`. Retry
+the same body with `Prefer: respond-async`.


### PR DESCRIPTION
# Summary

Corrects the `genomic-intelligence` skill against the live `/v1` contract. Every claim below was re-verified against `api.genomicintelligence.ai` at `2026.08.19.4` while writing this PR. The most important fix is a safety one: the guidance for detecting a wrong-strand splice call was wrong, and following it would let a silently incorrect result pass as valid.

## Type of change

- [x] Update to an existing skill
- [x] Documentation

## Skills touched

- genomic-intelligence

## What changed

**Splice strand — the wrong strand fails silently.** The model is strand-specific, but a reverse-complemented sequence does *not* return zeros or an empty result. Measured live across three loci:

| Fixture | Gene-sense | Reverse complement |
|---|---|---|
| BRCA1 exon 11 | 2 sites, 0.9998 / 0.9999 | 2 sites, 0.9101 / 0.9946 |
| HBB | 8 sites, all >= 0.9994 | 7 sites, 0.5187-0.9949 |
| SMN1 | 17 sites, all 0.9999 | 1 site, 0.6590 |

Positions and scores both move, and counts can collapse or hold depending on the locus — but neither score nor count identifies the mistake. There is no post-hoc check, so the skill now says to get orientation right on input rather than offering a heuristic.

**Delivery mode is per-request, not per-task.** `Prefer: respond-async` is declared on all six predict operations and on the composite; omitting it returns `200` synchronously on any of them, including `annotation`. The table column is labelled `Recommended mode` to reflect that it is latency guidance. The only enforced case is the composite rejecting sync above 50,000 bp with `413 sync_too_large`. Async is JSON-only.

**No templated-route fallback.** The six literal predict paths are matched first; any other task segment is `404 not_found`, never `422`.

**`max_seq_length_bp` is legacy and misleading.** It reads 500,000 everywhere except `g0-expression`, where it is 9,198 — the trained window, not a request cap. Gating on it wrongly rejects the 9,198-500,000 bp range expression actually accepts. The skill now points at `request_max_bp`, and documents `context_window_bp` as `null` for annotation and expression with `trained_window_bp` carrying the 9,198.

**Error handling.** `error.details` is keyed on the sibling `code` and its shape for `validation_failed` has varied across deployments, so the skill now says to treat it as display-only and branch on `code`. For correlation it reads the `X-Request-Id` header; `error.request_id` carries the same value and success envelopes carry `meta.request_id`. Reading the header first is a safe default, not a workaround.

**Housekeeping.** Removed a stale note claiming production might still serve `2026.08.18.1`; noted that a client *generated* from the OpenAPI document needs regenerating since the shared `PredictRequest` model is gone; documented the by-hand equivalent of the composite workflow.

`metadata.version` bumped `1.0` -> `1.1`.

## How this was tested

```
uv run skills-ref validate ./skills/genomic-intelligence   # Valid skill
uv run pytest tests/_meta -q                               # 10 passed, 1213 subtests
```

Repo-specific spec rules (`metadata.version`, block-mapping metadata, quoted scalars, nested `openclaw`) checked locally and clean. `SKILL.md` is 362 lines, under the 500-line limit. No scripts ship with this skill, so there is no `tests/genomic-intelligence/` suite to update. Docs-only: no behavioural change to any script.
