### PR TITLE
fix(stable-baselines3): repair broken API reference links

### DIFF
--- a/skills/stable-baselines3/SKILL.md
+++ b/skills/stable-baselines3/SKILL.md
@@ -5,7 +5,7 @@ license: MIT license
 allowed-tools: Read Write Edit Bash
 compatibility: Requires Python 3.10+, PyTorch >= 2.3, and stable-baselines3 2.8+. Gymnasium environments; optional extras for TensorBoard and Atari (ale-py).
 metadata:
-  version: "1.1"
+  version: "1.2"
   skill-author: K-Dense Inc.
 ---
 

--- a/skills/stable-baselines3/references/callbacks.md
+++ b/skills/stable-baselines3/references/callbacks.md
@@ -567,5 +567,5 @@ class DebugCallback(BaseCallback):
 ## Additional Resources
 
 - Official SB3 Callbacks Guide: https://stable-baselines3.readthedocs.io/en/master/guide/callbacks.html
-- Callback API Reference: https://stable-baselines3.readthedocs.io/en/master/common/callbacks.html
+- Callback API Reference: https://stable-baselines3.readthedocs.io/en/master/guide/callbacks.html#module-stable_baselines3.common.callbacks
 - TensorBoard Documentation: https://www.tensorflow.org/tensorboard

--- a/skills/stable-baselines3/references/vectorized_envs.md
+++ b/skills/stable-baselines3/references/vectorized_envs.md
@@ -576,5 +576,5 @@ model = PPO.load("model", env=eval_env)
 ## Additional Resources
 
 - Official SB3 VecEnv Guide: https://stable-baselines3.readthedocs.io/en/master/guide/vec_envs.html
-- VecEnv API Reference: https://stable-baselines3.readthedocs.io/en/master/common/vec_env.html
+- VecEnv API Reference: https://stable-baselines3.readthedocs.io/en/master/guide/vec_envs.html#module-stable_baselines3.common.vec_env
 - Multiprocessing Best Practices: https://docs.python.org/3/library/multiprocessing.html


### PR DESCRIPTION
Two "API Reference" links in the `stable-baselines3` skill return 404.

## Broken

- `skills/stable-baselines3/references/callbacks.md:570`
  `https://stable-baselines3.readthedocs.io/en/master/common/callbacks.html` — 404
- `skills/stable-baselines3/references/vectorized_envs.md:579`
  `https://stable-baselines3.readthedocs.io/en/master/common/vec_env.html` — 404

## Cause

Upstream Stable-Baselines3 documents `stable_baselines3.common.callbacks` and
`stable_baselines3.common.vec_env` on the same pages as their narrative guides.
There is no `common/` path for either module.

The "Official ... Guide" bullet directly above each broken link already used the
correct `guide/` path, so the two `common/` URLs were inconsistent within their
own files.

## Fix

Repointed both at the module anchors on the guide pages, which keeps the
"Guide" and "API Reference" bullets pointing at distinct targets:

- `guide/callbacks.html#module-stable_baselines3.common.callbacks`
- `guide/vec_envs.html#module-stable_baselines3.common.vec_env`

## Verification

- Both replacement URLs return HTTP 200.
- Both anchor ids (`id="module-stable_baselines3.common.callbacks"`,
  `id="module-stable_baselines3.common.vec_env"`) confirmed present in the
  rendered HTML.
- Cross-checked against the upstream `genindex.html`, which resolves every
  `stable_baselines3.common.callbacks.*` and `stable_baselines3.common.vec_env.*`
  entry to these guide pages — confirming no `common/` page exists.
- `uv run skills-ref validate ./skills/stable-baselines3` passes.
- `uv run --with pytest python -m pytest tests/_meta -q` shows no new failures
  against a pre-change baseline.

## Notes

- Bumped `metadata.version` from `"1.1"` to `"1.2"` per CONTRIBUTING.
- Documentation-only change; no `scripts/` touched, so no security scan was run.
