### PR TITLE
Add DataLad skill for dataset access and computational provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
 [![Version](https://img.shields.io/badge/Version-2.64.0-blue.svg)](pyproject.toml)
-[![Skills](https://img.shields.io/badge/Skills-163-brightgreen.svg)](#-whats-included)
+[![Skills](https://img.shields.io/badge/Skills-164-brightgreen.svg)](#-whats-included)
 [![Databases](https://img.shields.io/badge/Databases-100%2B-orange.svg)](#-whats-included)
 [![Agent Skills](https://img.shields.io/badge/Standard-Agent_Skills-blueviolet.svg)](https://agentskills.io/)
 [![Agent Plugins](https://img.shields.io/badge/Standard-Agent_Plugins-0A7A72.svg)](https://agent-plugins.org/)
@@ -16,14 +16,14 @@
 
 > **🔔 Claude Scientific Skills is now Scientific Agent Skills.** Same skills, broader compatibility — now works with any AI agent that supports the open [Agent Skills](https://agentskills.io/) standard, not just Claude.
 
-> **New: [K-Dense BYOK](https://github.com/K-Dense-AI/k-dense-byok)** — A free, open-source AI co-scientist that runs on your desktop, powered by Scientific Agent Skills. Bring your own API keys, pick from 40+ models, and get a full research workspace with web search, file handling, 100+ scientific databases, and access to all 161 skills in this repo. Your data stays on your computer, and you can optionally scale to cloud compute via [Modal](https://modal.com/) for heavy workloads. [Get started here.](https://github.com/K-Dense-AI/k-dense-byok)
+> **New: [K-Dense BYOK](https://github.com/K-Dense-AI/k-dense-byok)** — A free, open-source AI co-scientist that runs on your desktop, powered by Scientific Agent Skills. Bring your own API keys, pick from 40+ models, and get a full research workspace with web search, file handling, 100+ scientific databases, and access to all 164 skills in this repo. Your data stays on your computer, and you can optionally scale to cloud compute via [Modal](https://modal.com/) for heavy workloads. [Get started here.](https://github.com/K-Dense-AI/k-dense-byok)
 
 > **🎥 Live webinar — [Getting Started with K-Dense BYOK](https://luma.com/nucztxt5)** · Tuesday, August 25, 2026 · 2:00 PM PT / 5:00 PM ET · Online, free
 > Join us for a hands-on walkthrough of [K-Dense BYOK](https://github.com/K-Dense-AI/k-dense-byok), our free, open-source AI co-scientist that runs locally on your own machine and is powered by Scientific Agent Skills. We'll show you how to set it up, bring your own API keys, and run real research workflows with these skills. No prior technical experience needed, and questions are welcome throughout. **[Save your spot →](https://luma.com/nucztxt5)**
 
 > **Stay up to date:** Follow K-Dense on [X](https://x.com/k_dense_ai), [LinkedIn](https://www.linkedin.com/company/k-dense-inc), [YouTube](https://www.youtube.com/@K-Dense-Inc), and [Reddit](https://www.reddit.com/user/-k-dense-/) for new skills, release announcements, walkthroughs, research workflow demos, and examples you can use with your own AI agent.
 
-A comprehensive collection of **163 ready-to-use scientific and research skills** (covering cancer genomics, individual-level 1000 Genomes queries, hosted regulatory-sequence prediction, live pathogen-variant surveillance, analytical method validation, PK/PD modelling and dose selection, full-text biomedical and regulatory literature retrieval, drug-target binding, bounded biomedical knowledge graph search, molecular dynamics, RNA velocity, microbiome foundation models, geospatial science, time series forecasting, scientific ML resource discovery via Hugging Science, 78+ scientific databases, and more) for any AI agent that supports the open [Agent Skills](https://agentskills.io/) standard, created by [K-Dense](https://k-dense.ai). The repository is also a portable [Agent Plugins](https://agent-plugins.org/) package (`plugin.json` + `skills/`), so plugin-capable clients can load the whole collection as one plugin. Works with **Cursor, Claude Code, Codex, Google Antigravity, and more**. Transform your AI agent into a research assistant capable of executing complex multi-step scientific workflows across biology, chemistry, medicine, and beyond.
+A comprehensive collection of **164 ready-to-use scientific and research skills** (covering cancer genomics, individual-level 1000 Genomes queries, hosted regulatory-sequence prediction, live pathogen-variant surveillance, analytical method validation, PK/PD modelling and dose selection, full-text biomedical and regulatory literature retrieval, drug-target binding, bounded biomedical knowledge graph search, molecular dynamics, RNA velocity, microbiome foundation models, geospatial science, time series forecasting, scientific ML resource discovery via Hugging Science, 78+ scientific databases, and more) for any AI agent that supports the open [Agent Skills](https://agentskills.io/) standard, created by [K-Dense](https://k-dense.ai). The repository is also a portable [Agent Plugins](https://agent-plugins.org/) package (`plugin.json` + `skills/`), so plugin-capable clients can load the whole collection as one plugin. Works with **Cursor, Claude Code, Codex, Google Antigravity, and more**. Transform your AI agent into a research assistant capable of executing complex multi-step scientific workflows across biology, chemistry, medicine, and beyond.
 
 > ⭐ **Help make AI for science easier to discover:** If Scientific Agent Skills saves you time, teaches your agent a workflow, or helps your lab move faster, please [star this repository](https://github.com/K-Dense-AI/scientific-agent-skills). A star is a public signal that these open, reusable research skills are worth maintaining: it helps scientists, engineers, and open-source contributors find the project, shows which agent-skill standards are gaining real adoption, and gives us a clear reason to keep expanding the collection for the community.
 
@@ -70,7 +70,7 @@ Recorded walkthroughs of these skills on real research tasks, from the [K-Dense 
 
 ## 📦 What's Included
 
-This repository provides **163 scientific and research skills** organized into the following categories:
+This repository provides **164 scientific and research skills** organized into the following categories:
 
 - **100+ Scientific & Financial Databases** - A unified database-lookup skill provides deterministic, provenance-rich access to 78 public databases (PubChem, ChEMBL, UniProt, COSMIC, ClinicalTrials.gov, FRED, USPTO, and more), plus dedicated skills for DepMap, Imaging Data Commons, PrimeKG, NCATS ARAX, U.S. Treasury Fiscal Data, Hugging Science, OneKGPd, and Genomic Intelligence. Multi-database packages like BioServices (~40 bioinformatics services), BioPython (39 NCBI sub-databases via Entrez), and gget (20+ genomics databases) add further coverage
 - **70+ Optimized Python Package Skills** - Explicitly defined, version-aware workflows for RDKit, Scanpy, PyTorch Lightning, scikit-learn, PyTDC, PathML, pydicom, NeuroKit2, PufferLib, QuTiP, GeoPandas, pymatgen, BioPython, Qiskit, Molecular Dynamics (OpenMM/MDAnalysis), and others. The agent can still use *any* Python package; these skills provide stronger, safer guidance for the packages listed
@@ -117,7 +117,7 @@ Each skill includes:
 - **Multi-Step Workflows** - Execute complex pipelines with a single prompt
 
 ### 🎯 **Comprehensive Coverage**
-- **161 Skills** - Extensive coverage across all major scientific domains
+- **164 Skills** - Extensive coverage across all major scientific domains
 - **100+ Databases** - Unified access to 78+ databases via database-lookup, plus dedicated data access skills and multi-database packages like BioServices, BioPython, and gget
 - **70+ Optimized Python Package Skills** - Current, version-scoped guidance for packages including RDKit, Scanpy, PyTorch Lightning, scikit-learn, PyTDC, pydicom, PufferLib, QuTiP, GeoPandas, pymatgen, Qiskit, Molecular Dynamics (OpenMM/MDAnalysis), scVelo, and TimesFM (the agent can use any Python package; these are the pre-documented paths)
 
@@ -224,7 +224,7 @@ For Hermes versions that support skill taps, add the repository as a tap:
 hermes skills tap add K-Dense-AI/scientific-agent-skills
 ```
 
-Every `SKILL.md` has YAML frontmatter, but legacy and community skills vary in `metadata` formatting (block or flow style) and optional extension fields. Repository updates must keep `metadata.version` as a quoted numeric string and pass canonical `skills-ref validate ./skills/<skill-name>` checks. Hosts may interpret optional metadata and credential prompts differently, so verify behavior on the target host. Because 161 skills add up to a lot of standing context, consider installing a topical subset rather than the whole collection.
+Every `SKILL.md` has YAML frontmatter, but legacy and community skills vary in `metadata` formatting (block or flow style) and optional extension fields. Repository updates must keep `metadata.version` as a quoted numeric string and pass canonical `skills-ref validate ./skills/<skill-name>` checks. Hosts may interpret optional metadata and credential prompts differently, so verify behavior on the target host. Because 164 skills add up to a lot of standing context, consider installing a topical subset rather than the whole collection.
 
 > **NemoClaw note:** NemoClaw runs agents inside NVIDIA OpenShell with default-deny outbound networking. Skills are discovered and loaded normally, but any skill that needs the network — package installs via `uv`, or API calls (Exa, Parallel, Benchling, NCBI, Materials Project, …) — only works once the operator pre-approves the relevant domains in the OpenShell TUI.
 
@@ -463,7 +463,7 @@ networks, and search GEO for similar patterns.
 
 ## 📚 Available Skills
 
-This repository contains **163 scientific and research skills** organized across multiple domains. Each skill provides comprehensive documentation, code examples, and best practices for working with scientific libraries, databases, and tools.
+This repository contains **164 scientific and research skills** organized across multiple domains. Each skill provides comprehensive documentation, code examples, and best practices for working with scientific libraries, databases, and tools.
 
 ### Skill Categories
 
@@ -507,8 +507,9 @@ This repository contains **163 scientific and research skills** organized across
 - Whole slide imaging: histolab and research-only PathML 3.0.5
 - Virtual spatial transcriptomics: noncommercial DeepSpot-M for transcriptome-wide spatial gene expression from 224x224 H&E tiles
 
-#### 🧠 **Neuroscience & Electrophysiology** (3 skills)
+#### 🧠 **Neuroscience & Electrophysiology** (4 skills)
 - Data standards: BIDS (Brain Imaging Data Structure for neuroscience and biomedical datasets)
+- Dataset distribution & provenance: [DataLad](skills/datalad/) (discover and fetch OpenNeuro, DANDI, and registry.datalad.org datasets file-by-file over git-annex, and record re-executable computational provenance with `datalad run`/`rerun`/`containers-run`)
 - Neural recordings: Neuropixels-Analysis (extracellular spikes, silicon probes, spike sorting)
 - Physiological signals: NeuroKit2 0.2.13 for reproducible research workflows—not diagnosis, monitoring decisions, or medical-device validation
 
@@ -873,7 +874,7 @@ Recommended practice:
   title = {Scientific Agent Skills: A Comprehensive Collection of Scientific Tools for AI Agents},
   year = {2026},
   url = {https://github.com/K-Dense-AI/scientific-agent-skills},
-  note = {161 skills covering databases, packages, integrations, and analysis tools}
+  note = {164 skills covering databases, packages, integrations, and analysis tools}
 }
 ```
 

--- a/skills/datalad/SKILL.md
+++ b/skills/datalad/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: datalad
+description: Discover, retrieve, and version scientific datasets with DataLad, and capture computational provenance so analyses can be re-executed verbatim. Use when working with OpenNeuro or DANDI datasets, registry.datalad.org, git-annex-backed data, datalad clone/get/drop, or when a workflow needs reproducible execution records via datalad run, rerun, or containers-run.
+license: MIT
+compatibility: Requires Python 3.10+ with datalad (tested with 1.6.2) and git. git-annex is required to retrieve annexed file content (most published datasets). containers-run needs the datalad-container extension plus Docker or Apptainer/Singularity. Needs network access for discovery, cloning, and downloads.
+metadata:
+  version: "1.0"
+  skill-author: ayobamiseun
+---
+
+# DataLad
+
+DataLad manages datasets as git repositories in which large or binary file *content* is
+tracked by git-annex and fetched on demand, while text and code live in git directly.
+Datasets nest (a superdataset links subdatasets at exact versions), and every command a
+dataset was produced by can be recorded in the git history and re-executed later. This
+skill covers three jobs: **finding** published datasets, **getting** their content, and
+**capturing provenance** so results are reproducible.
+
+## When to use
+
+- The data lives on OpenNeuro, DANDI, or another DataLad-published source, or the user
+  mentions DataLad, git-annex, `datalad run`, or registry.datalad.org.
+- Terabyte-scale collections must be browsed and fetched file-by-file instead of
+  downloaded wholesale.
+- An analysis should carry a machine-readable record of exactly which command, inputs,
+  and outputs produced each result (`datalad run` / `datalad rerun` /
+  `datalad containers-run`).
+
+**When not to use:** plain code repositories (use git), uploading to DANDI (use the
+`dandi` CLI), or one-off downloads where no versioning or provenance is wanted.
+
+Check the environment first — most failures are missing system dependencies, not usage
+errors:
+
+```bash
+datalad --version        # pip/uv install datalad
+git annex version        # from your OS package manager, e.g. brew install git-annex
+```
+
+Without git-annex, cloning an annexed dataset fails outright (`install(error)` —
+DataLad 1.6.2 requires git-annex >= 10.20230126). Install git-annex before touching
+published datasets; only `--no-annex` datasets work without it.
+
+## Finding datasets
+
+- **DataLad Registry** — <https://registry.datalad.org> indexes ~25k datasets (DANDI,
+  OpenNeuro, and other annexed or plain-git repositories). The web UI accepts free-text
+  and fielded queries (`url:github`, quoted phrases, `AND`/`OR`/`NOT`, parentheses).
+  There is no core CLI search: `datalad search` moved to the `datalad-deprecated`
+  extension, so do not suggest it.
+- **OpenNeuro** — every accession is a DataLad dataset at
+  `https://github.com/OpenNeuroDatasets/<accession>`, e.g. `ds000001`. Browse or search
+  accessions at <https://openneuro.org>.
+- **DANDI** — every dandiset is mirrored at `https://github.com/dandisets/<id>`, e.g.
+  `000003`. Search at <https://dandiarchive.org>.
+- The superdataset <https://datasets.datalad.org> (clonable as `///`) aggregates many
+  neuroscience collections as nested subdatasets.
+
+## Getting data
+
+Clone cheaply, then fetch only the content you need:
+
+```bash
+datalad clone https://github.com/OpenNeuroDatasets/ds000001.git
+cd ds000001
+
+datalad get sub-01/                  # fetch content for one directory
+datalad get -n -r .                  # install nested subdatasets, no file content (-n)
+datalad get -J 4 sub-0*/anat         # parallel jobs
+datalad drop sub-01/                 # free local space; content stays retrievable
+datalad status                       # what is modified / untracked
+```
+
+`get` is idempotent and resumable; `drop` refuses to remove content it cannot re-obtain
+unless forced (`--reckless availability` — avoid). For a whole nested collection,
+`datalad clone` + `datalad get -n -r` first, inspect, then `get` the leaves you need.
+The equivalent Python API mirrors the CLI:
+
+```python
+import datalad.api as dl
+ds = dl.clone("https://github.com/OpenNeuroDatasets/ds000001.git", path="ds000001")
+ds.get("sub-01/")
+```
+
+## Creating a dataset
+
+```bash
+datalad create -c text2git my-analysis   # text files in git, binaries annexed
+cd my-analysis
+# ... add code and data ...
+datalad save -m "raw inputs and analysis script"
+```
+
+`-c text2git` keeps scripts and small text outputs directly editable; without it,
+annexed files are locked read-only symlinks until `datalad unlock`. Use
+`datalad create --no-annex` only for pure-text datasets on machines without git-annex.
+To ingest a remote file *with* provenance, prefer `datalad download-url <URL>` over
+curl + save: it records the source URL so the file remains re-obtainable after `drop`.
+
+Register an existing published dataset as input to yours (version-pinned nesting, the
+YODA layout):
+
+```bash
+datalad clone -d . https://github.com/OpenNeuroDatasets/ds000001.git inputs/ds000001
+```
+
+## Capturing provenance: `datalad run`
+
+Wrap any shell command; DataLad fetches declared inputs, runs it, and commits changed
+outputs together with a structured record:
+
+```bash
+datalad run -m "count words" \
+  -i input.txt \
+  -o counts.txt \
+  "wc -w input.txt > counts.txt"
+```
+
+The commit message carries a machine-readable block:
+
+```text
+[DATALAD RUNCMD] count words
+
+=== Do not change lines below ===
+{
+ "cmd": "wc -w input.txt > counts.txt",
+ "dsid": "6be75724-52cf-47c1-b145-eeb74a90b3fe",
+ "exit": 0,
+ "inputs": ["input.txt"],
+ "outputs": ["counts.txt"],
+ "pwd": "."
+}
+^^^ Do not change lines above ^^^
+```
+
+Rules that matter:
+
+- Run from a **clean dataset** (`datalad status` empty) — otherwise unrelated
+  modifications are swept into the provenance commit. `--explicit` relaxes this and
+  saves only declared outputs; use it deliberately, since undeclared side effects are
+  then silently untracked.
+- Declare `-i`/`-o` even when the command would find the files anyway: inputs are
+  `get`-ed first (so reruns work on fresh clones) and outputs are unlocked before
+  execution (so annexed results can be overwritten).
+- Glob patterns work: `-i "sub-*/anat/*.nii.gz"`.
+- `--dry-run basic` previews what would run and where without executing.
+- A failing command (nonzero exit) leaves outputs uncommitted; fix and rerun — do not
+  `datalad save` a half-finished result by hand.
+
+## Re-executing: `datalad rerun`
+
+```bash
+datalad rerun HEAD          # repeat the run recorded in the last commit
+datalad rerun <shasum>      # repeat a specific recorded run
+datalad rerun --since=v1.0  # replay every run since a tag/commit
+datalad rerun --report HEAD # show the record without executing
+datalad rerun --script analysis.sh --since= HEAD   # export all runs as a shell script
+```
+
+`rerun` re-executes the recorded command against current content: if inputs changed, a
+new result commit is produced; if results are identical, DataLad notes there was
+nothing new to save. `--onto` and `--branch` replay runs onto another starting point
+for verification. This is the check that a result is actually regenerable — run it
+before claiming an analysis is reproducible.
+
+## Containers: fully portable provenance
+
+Shell commands rerun exactly only where the same software exists. The
+`datalad-container` extension pins the compute environment into the dataset itself.
+Install `datalad-container`; execution additionally needs Docker or
+Apptainer/Singularity on the machine. The command forms below match the extension's
+CLI, but treat the specific image and script names as illustrative:
+
+```bash
+datalad containers-add nilearn --url docker://nilearn/nilearn:latest
+datalad containers-list
+datalad containers-run -n nilearn -m "first-level GLM" \
+  -i inputs/ds000001/sub-01 \
+  -o results/sub-01 \
+  "python code/glm.py sub-01"
+```
+
+`containers-add` stores (and annexes) the image in the dataset; `containers-run` is
+`datalad run` with the command executed inside that image, so the run record includes
+the container. A later `datalad rerun` on another machine retrieves both data *and*
+environment. Singularity/Apptainer images travel best (single annexed file); Docker
+image layers are stored under `.datalad/environments/` and re-loaded on demand.
+
+## Caveats and checks
+
+- **git-annex absent** is the most common failure mode: `clone` of any annexed dataset
+  errors immediately. Diagnose with `git annex version`.
+- **Locked files**: writing to an annexed file fails with "permission denied" — use
+  `datalad run -o` (auto-unlocks) or `datalad unlock <file>`.
+- **Nested datasets**: `datalad status`/`save` operate on one dataset level; pass `-r`
+  (recursive) or `-d <superdataset>` when results span subdatasets. After changing a
+  subdataset, `datalad save` in the superdataset records the new pinned version.
+- **Do not edit** the `=== Do not change lines ===` block in run commits; `rerun`
+  parses it.
+- Provenance records are only as complete as the declared `-i`/`-o` — audit a rerun on
+  a fresh `datalad clone` of the dataset to prove the record is self-contained.
+- DataLad run records can be exported toward W3C PROV via `datalad-metalad`'s
+  `metalad_runprov` extractor, and BIDS provenance is being standardized as BEP028 —
+  relevant when a consumer asks for standards-based provenance rather than git history.
+
+## References
+
+- Handbook (task-oriented): <https://handbook.datalad.org> — "Basics: Run" chapter
+  covers `run`/`rerun`; "Computational reproducibility with software containers"
+  covers `containers-run`.
+- Command reference: <https://docs.datalad.org>
+- YODA principles for analysis layout: `datalad create -c yoda`, described in the
+  handbook's "YODA: Best practices" chapter.


### PR DESCRIPTION
# Summary

Adds a `datalad` skill covering the three things an agent needs DataLad for: finding published datasets, fetching their content on demand over git-annex, and recording computational provenance that can actually be re-executed. This is the request in #124, which you left open as accepted.

Following the guidance in that thread, the skill is weighted toward the provenance half rather than being a `datalad get` wrapper: `datalad run`, `rerun`, and `containers-run` get the most space, including the rules that make a run record self-contained (clean tree, declared `-i`/`-o`, why `--explicit` is a deliberate choice) and the point that a rerun on a fresh clone is the real test of reproducibility.

## Type of change

- [x] New skill
- [x] Documentation

## Skills touched

- datalad

## How this was tested

Verified against DataLad 1.6.2 and git-annex 10.20260717 on macOS.

```
uv run skills-ref validate skills/datalad
  -> Valid skill: skills/datalad

uv run --with pytest python -m pytest tests/_meta -q
  -> 10 passed, 1213 subtests passed  (before this change)
  -> 10 passed, 1214 subtests passed  (with skills/datalad)

uv run skill-scanner scan skills/datalad
  -> Status: [OK] SAFE / Max Severity: SAFE / Total Findings: 0
```

There is no `tests/datalad/` suite and no `tests/skill-requirements.toml` entry because the skill ships no `scripts/` — `tests/_meta` confirms none is required.

Beyond the repo checks, the documented commands were actually run:

- `clone` → `get sub-01/anat` → `drop` end to end against the real OpenNeuro `ds000001`. The annexed-symlink layout shown in the skill is from that run.
- `datalad run` and `datalad rerun` on a local dataset. The `[DATALAD RUNCMD]` record quoted in the skill is real output, and `rerun` was confirmed to regenerate results after an input changed.
- `datalad create -c yoda` plus the version-pinned `datalad clone -d . <url> inputs/<name>` nesting pattern, confirming the subdataset pin is auto-saved.
- Every documented flag (`--dry-run`, `--explicit`, `--report`, `--script`, `--onto`, `-J`, `--data`) checked against `--help`.

Two things testing corrected, which are worth flagging because both are easy to get wrong from memory:

1. **`datalad search` is no longer in core.** It now lives in `datalad-deprecated`, so the skill routes discovery through the registry web UI and explicitly tells agents not to suggest the CLI command.
2. **Cloning an annexed dataset without git-annex fails outright** (`install(error)`, requires git-annex >= 10.20230126) rather than leaving dangling symlinks. My first draft said the latter; the skill now describes the real failure, since this is the most common thing a user will hit.

## Related issues and references

- Closes #124.
- Handbook chapters the skill points at: [Basics: Run](https://handbook.datalad.org), computational reproducibility with containers, and YODA best practices.
- The provenance-standards note in the caveats reflects @yarikoptic's follow-up on #124 about W3C PROV — it points at `datalad-metalad`'s `metalad_runprov` extractor and BIDS [BEP028](https://bids.neuroimaging.io/bep028) as the route to standards-based export, without claiming the skill does that conversion itself.

---

## Checklist

**Skill format**

- [x] The skill directory name and the `name` frontmatter match exactly.
- [x] The skill directory contains only `SKILL.md` — no `tests/` directory and no `test_*.py` files.
- [x] `SKILL.md` has valid YAML frontmatter and a Markdown body.
- [x] Only the six spec-defined top-level fields are present; everything else lives under `metadata`.
- [x] `metadata` is a block mapping, not single-line JSON, and scalar values are quoted where needed.
- [ ] Any `metadata.openclaw` or `metadata.hermes` block is a nested mapping — n/a, the skill declares neither.
- [x] `metadata.version` exists and is quoted (`"1.0"`, new skill).
- [x] The `description` says both what the skill does and when an agent should use it.

**Validation and tests**

- [x] `uv run skills-ref validate ./skills/datalad` passes.
- [ ] Tests live in `tests/<skill-name>/` and new `scripts/` skills have a `skill-requirements.toml` entry — n/a, no `scripts/`.
- [x] Relevant test suites pass (`tests/_meta`, the suite CI blocks on).
- [x] Security scanner results are clean (SAFE, 0 findings).

**Content and safety**

- [x] Examples were tested, or are clearly marked as illustrative (see the container note below).
- [x] No secrets, credentials, private data, or unsafe instructions are included.
- [x] Credentials — n/a. The skill needs no credentials; system dependencies are named in `compatibility`.
- [x] Official documentation is linked (handbook, `docs.datalad.org`).

## Notes for reviewers

- **`containers-run` is the one section not executed end to end.** No Docker or Apptainer runtime was available on the test machine. The command forms are verified against the `datalad-container` CLI (`containers-add`, `containers-list`, `containers-run -n`), and the section says to treat the specific image and script names as illustrative. If you would rather that section be cut than shipped unexecuted, say so and I will drop it — though it is the part of DataLad that makes provenance portable across machines, so I think it earns its place with the caveat.
- **Scope check.** Placed under Neuroscience & Electrophysiology next to `bids`, which mirrors the reasoning in your #124 comment. Discovery is aimed at OpenNeuro, DANDI, and `registry.datalad.org` rather than presenting DataLad as general-purpose data versioning, to stay on the right side of the general-infrastructure line.
- **README counts.** Rolled the total to 164. Four references had drifted to 161 (the BYOK paragraph, the coverage bullet, the standing-context note, and the BibTeX `note` field) and now agree with the badge. Happy to split that into its own PR if you would rather keep this one to `skills/`.
- **No version bump** in `pyproject.toml` or `plugin.json` — recent skill-addition commits leave those to your release process. Tell me if you want it bumped here.
- One inconsistency worth recording: your comment on #197 tells that contributor `metadata` must be single-line flow style, but AGENTS.md, this PR template, and the `strictyaml` validator all require a block mapping. This PR uses block style. The #197 advice may need correcting so that contribution does not land unvalidatable.
