### PR TITLE
fix(rdkit): finish FractionCSP3 / CalcFractionCSP3 doc corrections

### DIFF
--- a/skills/rdkit/SKILL.md
+++ b/skills/rdkit/SKILL.md
@@ -5,7 +5,7 @@ license: BSD-3-Clause license
 allowed-tools: Read Write Edit Bash
 compatibility: Examples target RDKit 2026.03.x. Use conda-forge for the broadest binary support or PyPI package `rdkit` for supported platform wheels; `rdkit-pypi` is the legacy PyPI name.
 metadata:
-  version: "1.2"
+  version: "1.3"
   skill-author: K-Dense Inc.
 ---
 

--- a/skills/rdkit/references/api_reference.md
+++ b/skills/rdkit/references/api_reference.md
@@ -249,7 +249,7 @@ Additional descriptor calculations.
 - `rdMolDescriptors.CalcNumAromaticHeterocycles(mol)` - Aromatic heterocycles
 - `rdMolDescriptors.CalcNumSpiroAtoms(mol)` - Spiro atoms
 - `rdMolDescriptors.CalcNumBridgeheadAtoms(mol)` - Bridgehead atoms
-- `rdMolDescriptors.CalcFractionCsp3(mol)` - Fraction of sp3 carbons
+- `rdMolDescriptors.CalcFractionCSP3(mol)` - Fraction of sp3 carbons
 - `rdMolDescriptors.CalcLabuteASA(mol)` - Labute accessible surface area
 - `rdMolDescriptors.CalcTPSA(mol)` - TPSA
 - `rdMolDescriptors.CalcMolFormula(mol)` - Molecular formula

--- a/skills/rdkit/references/descriptors_reference.md
+++ b/skills/rdkit/references/descriptors_reference.md
@@ -197,10 +197,10 @@ Descriptors.NumAromaticAtoms(mol)
 
 ## Fraction Descriptors
 
-### FractionCsp3
+### FractionCSP3
 Fraction of carbons that are sp3 hybridized.
 ```python
-Descriptors.FractionCsp3(mol)
+Descriptors.FractionCSP3(mol)  # also Lipinski.FractionCSP3(mol)
 ```
 
 ## Complexity Descriptors
@@ -580,7 +580,7 @@ def molecular_complexity(mol):
         'BertzCT': Descriptors.BertzCT(mol),
         'NumRings': Descriptors.RingCount(mol),
         'NumRotBonds': Descriptors.NumRotatableBonds(mol),
-        'FractionCsp3': Descriptors.FractionCsp3(mol),
+        'FractionCSP3': Descriptors.FractionCSP3(mol),
         'NumAromaticRings': Descriptors.NumAromaticRings(mol)
     }
 ```


### PR DESCRIPTION
## Summary

PR #213 fixed `molecular_properties.py` to call `Lipinski.FractionCSP3`, but the reference docs still taught the old names that crash on RDKit 2026.03.x.

- `descriptors_reference.md`: `Descriptors.FractionCsp3` → `Descriptors.FractionCSP3` (section + diversity example)
- `api_reference.md`: `rdMolDescriptors.CalcFractionCsp3` → `CalcFractionCSP3`
- Bump `metadata.version` `"1.2"` → `"1.3"`

## Type of change

- [x] Update to an existing skill

## Skills touched

- rdkit

## How this was tested

```
$ uv run --with rdkit python - <<'PY'
from rdkit import Chem
from rdkit.Chem import Descriptors, Lipinski, rdMolDescriptors
m = Chem.MolFromSmiles('CC(=O)Oc1ccccc1C(=O)O')
Descriptors.FractionCsp3(m)          # AttributeError
Descriptors.FractionCSP3(m)          # 0.111...
Lipinski.FractionCSP3(m)             # 0.111...
rdMolDescriptors.CalcFractionCsp3(m) # AttributeError
rdMolDescriptors.CalcFractionCSP3(m) # 0.111...
PY

$ uv run skills-ref validate ./skills/rdkit
Valid skill: skills/rdkit

$ uv run --with pytest python -m pytest tests/_meta -q
10 passed, 1213 subtests passed
```

Against RDKit 2026.03.5.

## Related issues and references

Fixes #242. Completes the doc half of #213 / #97.

## Checklist

**Skill format**

- [x] The skill directory name and the `name` frontmatter match exactly.
- [x] The skill directory contains only `SKILL.md`, `references/`, `scripts/`, and `assets/` — no `tests/` directory and no `test_*.py` files.
- [x] `SKILL.md` has valid YAML frontmatter and a Markdown body.
- [x] Only the six spec-defined top-level fields are present; everything else lives under `metadata`.
- [x] `metadata` is a block mapping, not single-line JSON, and scalar values are quoted where needed.
- [x] `metadata.version` exists, is quoted, and is bumped if an existing skill changed.
- [x] The `description` says both what the skill does and when an agent should use it.

**Validation and tests**

- [x] `uv run skills-ref validate ./skills/rdkit` passes.
- [x] Relevant test suites pass (`tests/_meta`).
- [x] Security scanner results are clean or explained in this PR. — docs-only; no `scripts/` change, scanner not run.

**Content and safety**

- [x] Examples and scripts were tested, or are clearly marked as illustrative.
- [x] No secrets, credentials, private data, or unsafe instructions are included.

## Notes for reviewers

Left `MolToSmarts(..., isomericSmiles=False)` default documentation alone (same deliberate scope boundary as #213).

