### PR TITLE
fix(database-lookup): retire dead PatentsView search API for ODP

### DIFF
--- a/skills/database-lookup/SKILL.md
+++ b/skills/database-lookup/SKILL.md
@@ -4,7 +4,7 @@ description: Query documented public database APIs with explicit endpoints, filt
 allowed-tools: Read Bash
 license: MIT
 metadata:
-  version: "1.3"
+  version: "1.4"
   skill-author: "K-Dense Inc."
 ---
 
@@ -117,7 +117,7 @@ Some databases require API keys or have access restrictions. When an API key is 
 | BLS | `BLS_API_KEY` | https://data.bls.gov/registrationEngine/ |
 | NCBI (GEO, Gene) | `NCBI_API_KEY` | https://www.ncbi.nlm.nih.gov/account/settings/ |
 | OpenFDA | `OPENFDA_API_KEY` | https://open.fda.gov/apis/authentication/ |
-| USPTO (PatentsView) | `PATENTSVIEW_API_KEY` | https://patentsview.org/apis/keyrequest |
+| USPTO Open Data Portal (PatentsView bulk) | `USPTO_ODP_API_KEY` | https://data.uspto.gov/apikey |
 | Data Commons | `DATACOMMONS_API_KEY` | Google Cloud Console |
 | Materials Project | `MP_API_KEY` | https://materialsproject.org (free account) |
 | NASA | `NASA_API_KEY` | https://api.nasa.gov (free, DEMO_KEY available) |

--- a/skills/database-lookup/references/clinicaltrials.md
+++ b/skills/database-lookup/references/clinicaltrials.md
@@ -83,4 +83,22 @@ GET /studies/metadata
 Uses cursor-based pagination via `pageToken` (NOT numeric offsets). Include `countTotal=true` on first request to get total.
 
 ## Rate Limits
-No API key. Be reasonable — a few requests per second. Bulk: https://clinicaltrials.gov/AllAPIJSON.zip
+No API key. Be reasonable — a few requests per second.
+
+## Bulk download
+
+Prefer the v2 `/studies` API with `pageToken` pagination for programmatic
+retrieval. The former bulk URL `https://clinicaltrials.gov/AllAPIJSON.zip`
+returns **404** and must not be used.
+
+For a full-registry **XML** dump, use:
+
+```
+https://clinicaltrials.gov/AllPublicXML.zip
+```
+
+That path redirects to `https://clinicaltrials.gov/api/legacy/public-xml?format=zip`
+and returns `Content-Type: application/zip` (`ctg-public-xml.zip`). Confirm the
+redirect still yields a zip before large downloads; CSV / pipe-delimited export
+options are documented under ClinicalTrials.gov Data API “Download” pages when
+XML is not appropriate.

--- a/skills/database-lookup/references/database_selection_guide.md
+++ b/skills/database-lookup/references/database_selection_guide.md
@@ -126,8 +126,8 @@ Match the user's intent to the right database(s). Many queries benefit from hitt
 ### Patents & Regulatory
 | User is asking about... | Primary database(s) | Also consider |
 |---|---|---|
-| Patents by keyword or technology | USPTO (PatentsView) | — |
-| Patents by inventor or assignee | USPTO (PatentsView) | — |
+| Patents by keyword or technology | USPTO ODP PatentsView bulk (PatentSearch API paused) | — |
+| Patents by inventor or assignee | USPTO ODP PatentsView bulk (PatentSearch API paused) | — |
 | Patent prosecution status | USPTO (PEDS) | — |
 | Trademark lookup | USPTO (TSDR) | — |
 | SEC company filings, 10-K, 10-Q | SEC EDGAR | — |

--- a/skills/database-lookup/references/uspto.md
+++ b/skills/database-lookup/references/uspto.md
@@ -1,93 +1,57 @@
 # USPTO Public APIs
 
-## 1. PatentsView API (Primary Patent Search)
+## 1. PatentsView → Open Data Portal (ODP)
 
-The newer Elasticsearch-based API is the recommended endpoint.
+**Status (checked 2026-08-30):** The PatentsView PatentSearch API that lived at
+`https://search.patentsview.org/api/v1/` is **unavailable**. The host no longer
+resolves (NXDOMAIN). USPTO migrated PatentsView onto the Open Data Portal on
+2026-03-20; PatentSearch and related interactive features are paused with no
+published relaunch date. Do **not** call `search.patentsview.org`, do **not**
+register at the old `patentsview.org/apis/keyrequest` flow, and do **not** treat
+legacy `api.patentsview.org` query URLs as live search endpoints (they redirect
+to the transition guide).
 
-### Base URL
+### Current access path
 
-```
-https://search.patentsview.org/api/v1/
-```
+Use ODP for PatentsView **bulk datasets** and data dictionaries:
 
-**API key required** — register at `https://patentsview.org/apis/keyrequest`
+- Transition guide: https://data.uspto.gov/support/transition-guide/patentsview
+- PatentsView program page: https://www.uspto.gov/ip-policy/economic-research/patentsview
+- ODP home / bulk directory: https://data.uspto.gov/
 
-Pass as query parameter: `?api_key=YOUR_KEY`
+| Category | Example tables | ODP bulk dataset page |
+|---|---|---|
+| Granted patents — baseline / disambiguated | `g_patent`, `g_cpc_current`, `g_assignee_disambiguated` | https://data.uspto.gov/bulkdata/datasets/pvgpatdis |
+| Granted patents — long text | `g_brf_sum_text_*`, `g_claims_*`, `g_detail_desc_text_*` | https://data.uspto.gov/bulkdata/datasets/pvgpattxt |
+| Pre-grant publications — baseline / disambiguated | `pg_published_application`, `pg_cpc_current` | https://data.uspto.gov/bulkdata/datasets/pvpgpubdis |
+| Pre-grant publications — long text | `pg_brf_sum_text_*`, `pg_claims_*` | https://data.uspto.gov/bulkdata/datasets/pvpgpubtxt |
+| Sorted (beta) | `g_sorted_applicant`, `pg_sorted_individual` | https://data.uspto.gov/bulkdata/datasets/pvsorted |
+| Annualized | yearly CSV tables | https://data.uspto.gov/bulkdata/datasets/pvannual |
 
-### Key Endpoints
+Data dictionaries (when published) are linked from the “Documents and Resources”
+sidebar on each ODP dataset page above.
 
-#### Search patents
-```
-GET or POST /patent/
-```
+### Auth for ODP bulk / API access
 
-Query parameter `q` accepts a JSON query object.
+ODP access requires a USPTO.gov account (MFA). Obtain an **ODP** API key from
+https://data.uspto.gov/apikey — previously issued PatentsView PatentSearch keys
+are **not** compatible. Prefer loading the key from `.env` as `USPTO_ODP_API_KEY`
+and sending it with the header ODP documents for its Bulk Datasets API
+(commonly `X-API-KEY`). Never print the key in provenance.
 
-Operators: `_eq`, `_neq`, `_gt`, `_gte`, `_lt`, `_lte`, `_begins`, `_contains`, `_text_any`, `_text_all`, `_text_phrase`, `_and`, `_or`, `_not`
+If the user needs interactive keyword / inventor / assignee **search** rather
+than bulk tables, say clearly that PatentSearch is paused during the ODP
+transition and point them at the transition guide — do not invent a replacement
+search URL.
 
-Parameters:
-- `q` — JSON query
-- `f` — fields to return (JSON array)
-- `o` — options: `{"size": 25}` for pagination
-- `s` — sort: `[{"patent_date": "desc"}]`
+### Historical note
 
-#### Search by keyword
-```
-GET /patent/?q={"_text_any":{"patent_abstract":"autonomous vehicle"}}&f=["patent_id","patent_title","patent_date"]&o={"size":5}&api_key=KEY
-```
+- Legacy PatentsView REST host `api.patentsview.org` is decommissioned for search;
+  requests redirect to the ODP transition guide.
+- The Elasticsearch PatentSearch base URL `https://search.patentsview.org/api/v1/`
+  must not be used until USPTO republishes an ODP-hosted replacement.
 
-#### Search by inventor
-```
-GET /patent/?q={"inventors.inventor_name_last":"Tesla"}&f=["patent_id","patent_title","patent_date"]&api_key=KEY
-```
-
-#### Search by assignee
-```
-GET /patent/?q={"assignees.assignee_organization":"Google LLC"}&f=["patent_id","patent_title","patent_date","assignees"]&api_key=KEY
-```
-
-#### Lookup by patent number
-```
-GET /patent/{patent_number}/?api_key=KEY
-```
-
-#### Other entity endpoints
-```
-/inventor/
-/assignee/
-/cpc_group/
-```
-
-### Response Structure
-
-```json
-{
-  "patents": [
-    {
-      "patent_id": "11234567",
-      "patent_title": "...",
-      "patent_date": "2022-03-15",
-      "patent_abstract": "...",
-      "assignees": [{"assignee_organization": "..."}],
-      "inventors": [{"inventor_name_first": "...", "inventor_name_last": "..."}]
-    }
-  ],
-  "count": 1,
-  "total_hits": 8923
-}
-```
-
-### Rate Limits
-
-~45 requests per minute per API key.
-
-### Important Note
-
-The user must have a PatentsView API key for this endpoint. If they don't have one, let them know they need to register at `https://patentsview.org/apis/keyrequest`. Load the key from `.env` as `PATENTSVIEW_API_KEY`.
-
-**Note:** The legacy API at `api.patentsview.org` has been decommissioned (returns 410 Gone). Only the new API above works.
-
-## 3. PEDS — Patent Examination Data System
+## 2. PEDS — Patent Examination Data System
 
 **URL**: `https://ped.uspto.gov/api/queries`
 
@@ -109,7 +73,7 @@ For patent prosecution data (application status, filing dates, examiner info).
 
 No API key required but heavily rate limited. Availability can be unreliable.
 
-## 4. TSDR — Trademark Status & Document Retrieval
+## 3. TSDR — Trademark Status & Document Retrieval
 
 For trademark lookup by serial or registration number (not full-text search).
 
@@ -122,9 +86,10 @@ Returns XML with mark details, status, owner, goods/services, prosecution histor
 
 No API key. Rate limited. No JSON endpoint — responses are XML.
 
-## 5. Limitations
+## 4. Limitations
 
 - **No public REST API for trademark full-text search** (TESS is web-only)
-- PatentsView new API requires registration for an API key
+- **PatentsView PatentSearch API is paused** during the ODP migration; use ODP
+  bulk datasets for PatentsView tables until USPTO republishes search APIs
 - PEDS availability is inconsistent
 - TSDR requires knowing the serial/registration number already


### PR DESCRIPTION
## Summary

`references/uspto.md` still taught `https://search.patentsview.org/api/v1/` as the primary PatentsView search API. After USPTO's 2026-03-20 Open Data Portal migration that host is NXDOMAIN, so every agent following the skill hard-fails. The old `patentsview.org/apis/keyrequest` flow is also obsolete.

This PR:

- Rewrites the PatentsView section around the [ODP transition guide](https://data.uspto.gov/support/transition-guide/patentsview) and the published PatentsView bulk dataset pages
- Marks PatentSearch as paused (no invented replacement search URL)
- Swaps the credentials row from `PATENTSVIEW_API_KEY` / keyrequest to `USPTO_ODP_API_KEY` / https://data.uspto.gov/apikey
- Notes the pause in `database_selection_guide.md`
- Replaces the 404 ClinicalTrials bulk URL `AllAPIJSON.zip` with the working `AllPublicXML.zip` → legacy public-xml zip path
- Bumps `metadata.version` to `"1.4"`

PEDS and TSDR sections are unchanged.

## Type of change

- [x] Update to an existing skill

## Skills touched

- database-lookup

## How this was tested

```
$ host search.patentsview.org
Host search.patentsview.org not found: 3(NXDOMAIN)

$ curl -sI -L https://api.patentsview.org/patents/query
# 301 → https://data.uspto.gov/support/transition-guide/patentsview (200)

$ curl -sI https://clinicaltrials.gov/AllAPIJSON.zip
# 404

$ curl -sIL https://clinicaltrials.gov/AllPublicXML.zip
# 301 → /api/legacy/public-xml?format=zip
# 200 application/zip  content-disposition: attachment; filename=ctg-public-xml.zip

$ curl -sI https://data.uspto.gov/support/transition-guide/patentsview
# 200

$ uv run skills-ref validate ./skills/database-lookup
Valid skill: skills/database-lookup

$ uv run --with pytest python -m pytest tests/_meta -q
10 passed, 1213 subtests passed
```

Checked 2026-08-30 against USPTO's published transition guidance (PatentSearch paused; bulk tables on ODP).

## Related issues and references

Fixes #243.

- https://data.uspto.gov/support/transition-guide/patentsview
- https://www.uspto.gov/subscription-center/2026/patentsview-migrating-uspto-open-data-portal-march-20

## Checklist

**Skill format**

- [x] The skill directory name and the `name` frontmatter match exactly.
- [x] The skill directory contains only `SKILL.md`, `references/`, `scripts/`, and `assets/`.
- [x] `SKILL.md` has valid YAML frontmatter and a Markdown body.
- [x] Only the six spec-defined top-level fields are present; everything else lives under `metadata`.
- [x] `metadata` is a block mapping, not single-line JSON, and scalar values are quoted where needed.
- [x] `metadata.version` exists, is quoted, and is bumped.
- [x] The `description` says both what the skill does and when an agent should use it.

**Validation and tests**

- [x] `uv run skills-ref validate ./skills/database-lookup` passes.
- [x] `tests/_meta` passes.
- [x] Security scanner — docs-only change; scanner not run.

**Content and safety**

- [x] Examples and scripts were tested, or are clearly marked as illustrative.
- [x] No secrets, credentials, private data, or unsafe instructions are included.
- [x] Credentials the skill needs are named in the credentials table (`USPTO_ODP_API_KEY`).

## Notes for reviewers

- I did not invent a replacement PatentSearch base URL; USPTO has not published one yet. Agents are steered to ODP bulk datasets and told to surface the pause when interactive search is requested.
- `USPTO_ODP_API_KEY` is the local `.env` name for the ODP key (header per ODP docs). Old `PATENTSVIEW_API_KEY` values are incompatible per USPTO.

