### PR TITLE
fix(rdkit): correct FractionCSP3 / CalcFractionCSP3 casing in docs (fixes #242)

### DIFF
--- a/skills/rdkit/SKILL.md
+++ b/skills/rdkit/SKILL.md
@@ -5,7 +5,7 @@ license: BSD-3-Clause license
 allowed-tools: Read Write Edit Bash
 compatibility: Examples target RDKit 2026.03.x. Use conda-forge for the broadest binary support or PyPI package `rdkit` for supported platform wheels; `rdkit-pypi` is the legacy PyPI name.
 metadata:
-  version: "1.2"
+  version: "1.3"
   skill-author: K-Dense Inc.
 ---
 

--- a/skills/rdkit/references/api_reference.md
+++ b/skills/rdkit/references/api_reference.md
@@ -249,7 +249,7 @@ Additional descriptor calculations.
 - `rdMolDescriptors.CalcNumAromaticHeterocycles(mol)` - Aromatic heterocycles
 - `rdMolDescriptors.CalcNumSpiroAtoms(mol)` - Spiro atoms
 - `rdMolDescriptors.CalcNumBridgeheadAtoms(mol)` - Bridgehead atoms
-- `rdMolDescriptors.CalcFractionCsp3(mol)` - Fraction of sp3 carbons
+- `rdMolDescriptors.CalcFractionCSP3(mol)` - Fraction of sp3 carbons
 - `rdMolDescriptors.CalcLabuteASA(mol)` - Labute accessible surface area
 - `rdMolDescriptors.CalcTPSA(mol)` - TPSA
 - `rdMolDescriptors.CalcMolFormula(mol)` - Molecular formula

--- a/skills/rdkit/references/descriptors_reference.md
+++ b/skills/rdkit/references/descriptors_reference.md
@@ -197,10 +197,10 @@ Descriptors.NumAromaticAtoms(mol)
 
 ## Fraction Descriptors
 
-### FractionCsp3
+### FractionCSP3
 Fraction of carbons that are sp3 hybridized.
 ```python
-Descriptors.FractionCsp3(mol)
+Descriptors.FractionCSP3(mol)
 ```
 
 ## Complexity Descriptors
@@ -580,7 +580,7 @@ def molecular_complexity(mol):
         'BertzCT': Descriptors.BertzCT(mol),
         'NumRings': Descriptors.RingCount(mol),
         'NumRotBonds': Descriptors.NumRotatableBonds(mol),
-        'FractionCsp3': Descriptors.FractionCsp3(mol),
+        'FractionCSP3': Descriptors.FractionCSP3(mol),
         'NumAromaticRings': Descriptors.NumAromaticRings(mol)
     }
 ```


### PR DESCRIPTION
## Summary

Fixes #242. PR #213 fixed `skills/rdkit/scripts/molecular_properties.py` to use `Lipinski.FractionCSP3`, but reference docs still documented the broken names `Descriptors.FractionCsp3` and `rdMolDescriptors.CalcFractionCsp3`.

Against RDKit 2026.03.x those throw:

```python
Descriptors.FractionCsp3(mol)
# AttributeError: module 'rdkit.Chem.Descriptors' has no attribute 'FractionCsp3'

rdMolDescriptors.CalcFractionCsp3(mol)
# AttributeError: ... Did you mean: 'CalcFractionCSP3'?
```

This PR updates the documented APIs to the working names:
- `Descriptors.FractionCSP3` / `Lipinski.FractionCSP3`
- `rdMolDescriptors.CalcFractionCSP3`

Changes:
- `skills/rdkit/references/descriptors_reference.md`: section title, usage snippet and diversity helper (`FractionCsp3` → `FractionCSP3`)
- `skills/rdkit/references/api_reference.md`: `CalcFractionCsp3` → `CalcFractionCSP3`
- `skills/rdkit/SKILL.md`: bump `metadata.version` `1.2` → `1.3`

## How tested

```bash
uv run --with rdkit python -c "from rdkit import Chem; from rdkit.Chem import Descriptors; from rdkit.Chem import rdMolDescriptors; mol=Chem.MolFromSmiles('CCO'); print(Descriptors.FractionCSP3(mol)); print(rdMolDescriptors.CalcFractionCSP3(mol))"
# 1.0 / 1.0

uv run skills-ref validate ./skills/rdkit
# Valid skill: skills/rdkit

uv run --with pytest python -m pytest tests/_meta -q
# 10 passed, 1213 subtests passed
```

Verified the old names are absent (`grep -rn FractionCsp3`) and no longer exist in the installed RDKit.

Fixes #242.