### PR TITLE
fix(security): remove TODO placeholder from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,9 +14,6 @@ Use GitHub's private vulnerability reporting, which keeps the report confidentia
 
 > **Security** tab → **Report a vulnerability**
 
-<!-- TODO(maintainers): add a monitored security contact address here as a second channel,
-     or delete this comment if private vulnerability reporting is the only intended route. -->
-
 Please include, as far as you are able:
 
 - The affected skill (or repository tooling) and the version or commit you observed it on


### PR DESCRIPTION
# Summary
Remove lingering maintainer `TODO` placeholder from the repository's GitHub-surfaced security policy. The HTML comment suggested adding a monitored `security@` address or deleting it if private vulnerability reporting is the sole channel — the latter is current practice.

## Type of change
- [ ] New skill
- [ ] Update to an existing skill
- [ ] Tests
- [x] Repository tooling or CI
- [x] Documentation
- [ ] Other:

## Skills touched
none

## How this was tested
```
git diff --stat  # 1 file changed, 3 deletions
cat SECURITY.md  # private reporting via Security tab → Report a vulnerability remains, no TODO
grep -r TODO SECURITY.md  # no results
```
- Verified file renders correctly on GitHub and private reporting instructions intact
- No skill validation needed (`skills/` untouched); `uv run --with pytest python -m pytest tests/_meta -q` unaffected (policy docs not covered by skill contract)

## Related issues and references
- Closes the `SECURITY.md TODO` flagged by `grep -r TODO` audit (reported in recon)
- The TODO comment itself references deletion when private reporting is the only intended route — see `SECURITY.md:17` before this change

---

## Checklist

**Skill format**

- [ ] The skill directory name and the `name` frontmatter match exactly. (N/A — no skill touched)
- [ ] The skill directory contains only `SKILL.md`, `references/`, `scripts/`, and `assets/` — no `tests/` directory and no `test_*.py` files. (N/A)
- [ ] `SKILL.md` has valid YAML frontmatter and a Markdown body. (N/A)
- [ ] Only the six spec-defined top-level fields are present; everything else lives under `metadata`. (N/A)
- [ ] `metadata` is a block mapping, not single-line JSON, and scalar values are quoted where needed. (N/A)
- [ ] Any `metadata.openclaw` or `metadata.hermes` block is a nested mapping, not a JSON string. (N/A)
- [ ] `metadata.version` exists, is quoted, and is bumped if an existing skill changed. (N/A)
- [ ] The `description` says both what the skill does and when an agent should use it. (N/A)

**Validation and tests**

- [ ] `uv run skills-ref validate ./skills/<name>` passes. (N/A — no skill changed)
- [ ] Tests live in `tests/<skill-name>/`, and any new `scripts/` skill has a `[skills.<name>]` entry in `tests/skill-requirements.toml`. (N/A)
- [x] Relevant test suites pass, or the failures are explained below. (`tests/_meta` unaffected)
- [x] Security scanner results are clean or explained in this PR. (No code change, no new scan findings)

**Content and safety**

- [x] Examples and scripts were tested, or are clearly marked as illustrative. (No examples)
- [x] No secrets, credentials, private data, or unsafe instructions are included.
- [x] Credentials the skill needs are named in `compatibility` and declared in `metadata.openclaw.envVars`. (N/A)
- [x] Relevant official documentation is linked where useful. (GitHub private vulnerability reporting)

## Notes for reviewers
- This is a docs-only change; no `plugin.json`/`pyproject.toml` version bump needed (collection version unchanged)
- Low risk; removes 3 lines, preserves authoritative private reporting channel
