### PR TITLE
Add verify-citations skill: reference audit with retraction and hallucination checks

### DIFF
--- a/skills/verify-citations/SKILL.md
+++ b/skills/verify-citations/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: verify-citations
+description: Audit the references of a scientific manuscript against live bibliographic databases before submission or review. Detects hallucinated references that resolve nowhere, flags retracted or withdrawn papers via Crossref and OpenAlex, catches metadata mismatches (wrong year, wrong authors, garbled titles) that signal LLM-mangled citations, and renders a per-citation markdown audit report with a shared verdict taxonomy. This skill should be used when fact-checking a manuscript's bibliography, checking citations for retraction, auditing AI-generated references, or preparing a camera-ready reference list.
+allowed-tools: Read Write Edit Bash WebFetch
+license: MIT License
+compatibility: Python 3.9+. Network access needed for api.crossref.org, export.arxiv.org, eutils.ncbi.nlm.nih.gov, and api.openalex.org (all keyless; CROSSREF_EMAIL/OPENALEX_EMAIL enable polite pools). Report generation is offline.
+metadata:
+  version: "1.0"
+  skill-author: Prajwal Rawoorkar
+---
+
+# Verify Citations
+
+Audit a manuscript's references against live sources and report, per citation,
+whether the work exists, whether the stated details match it, and whether it
+has been retracted.
+
+LLM-assisted writing has made two failure modes common: references that look
+plausible but do not exist, and references that point at a real paper while
+stating the wrong year, authors, or title. Both survive casual proofreading.
+This skill runs a systematic pass instead: parse the reference list, resolve
+every entry against Crossref/arXiv/PubMed, compare stated metadata with the
+canonical record, check retraction status, and render an audit report.
+
+This complements `citation-management` (which finds, formats, and generates
+references); this skill audits an existing list.
+
+## When to Use
+
+Use this skill when:
+- Fact-checking a manuscript's bibliography before submission
+- Auditing references in AI-generated or AI-assisted text
+- Checking whether any cited work has been retracted or withdrawn
+- Verifying that cited metadata (authors, year, venue) matches reality
+- Producing an audit trail of citation quality for co-authors or reviewers
+
+## Workflow
+
+### 1. Parse the reference list
+
+Extract a structured reference list from markdown, LaTeX, or BibTeX:
+
+```bash
+python scripts/parse_references.py manuscript.md --output refs.json
+python scripts/parse_references.py manuscript.tex --in-text --output refs.json
+python scripts/parse_references.py references.bib --output refs.json
+```
+
+The parser is permissive: an entry survives on any identifier (DOI, arXiv ID,
+PMID) or title it can recover. `--in-text` additionally extracts checkable
+citation sentences (those carrying statistics or quoted phrases) for manual
+claim inspection.
+
+### 2. Verify the references
+
+Resolve every entry and assign a verdict:
+
+```bash
+python scripts/verify_references.py refs.json --output verification.json
+```
+
+Resolution order per entry: DOI -> Crossref, arXiv ID -> arXiv Atom API, PMID
+-> PubMed E-utilities, then Crossref bibliographic search for title-only
+entries (best title similarity wins, threshold 0.85). Set
+`CROSSREF_EMAIL`/`OPENALEX_EMAIL` to join provider polite pools.
+
+Verdicts (shared taxonomy, see `references/verdicts.md`):
+
+| Verdict | Meaning |
+|---|---|
+| `verified` | resolved; stated metadata matches the source |
+| `metadata-mismatch` | resolved, but stated details disagree -- wrong year, wrong first author, or a garbled title |
+| `retracted` | the work has been retracted or withdrawn |
+| `not-found` | no provider knows the work -- prime hallucination suspect |
+| `unresolved` | network/API error prevented checking |
+| `skipped` | nothing checkable (no identifier, no title) |
+
+The retraction check runs inside this pass when Crossref supplies
+`update-to`/`updated-by` metadata.
+
+### 3. Standalone retraction sweep (optional)
+
+Check an existing DOI list or .bib file for retractions without full
+verification:
+
+```bash
+python scripts/check_retractions.py references.bib --output retractions.json
+python scripts/check_retractions.py --doi 10.1038/s41586-021-03819-2
+```
+
+Crossref is the primary source (official retraction notices); OpenAlex
+`is_retracted` is the fallback.
+
+### 4. Render the audit report
+
+```bash
+python scripts/generate_report.py verification.json --output audit.md --title "Manuscript v3 citation audit"
+```
+
+The report lists flagged references worst-first (retracted -> metadata
+mismatch -> not found), with the stated-vs-resolved details and mismatch
+reasons for each, then the full reference table for the record.
+
+## Worked example
+
+Given a manuscript with a hallucinated reference and a year typo:
+
+```
+[1] Vaswani, A. et al. (2017). Attention Is All You Need. NeurIPS.
+[2] Zhang, L. (2023). Scaling laws for reward model overoptimization. NeurIPS.  <- wrong author/year
+[3] Smith, J. (2022). Quantum leverage in protein folding. Nature.  <- does not exist
+```
+
+`verify_references.py` reports `[1] verified`, `[2] metadata-mismatch`
+(resolved author Gao, resolved year 2022 via Crossref search), `[3] not-found`
+-- and `generate_report.py` renders the actionable audit.
+
+## Interpreting results
+
+- **Verdicts are evidence, not judgement.** `not-found` on genuinely obscure
+  documents (theses, datasets, grey literature) can be a false positive;
+  hand-verify flagged items before removing them.
+- **`metadata-mismatch` is the high-signal verdict** for LLM-written text:
+  the cited work is real, but the manuscript describes a different one.
+- Title-only matching uses a similarity threshold; short titles increase
+  false-match risk, so prefer entries that carry a DOI.
+
+## Important caveats
+
+- Crossref, arXiv, and PubMed cover published/preprint literature; they will
+  not find textbooks, websites, software, or most grey literature. Entries
+  without DOI/arXiv/PMID and a title fall back to search or are skipped.
+- Rate limits: the scripts pause 1s between provider calls by default
+  (`--pause`); polite-pool emails raise the anonymous ceilings considerably.
+- In-text claim verification (does the source support the sentence?) is a
+  reading task for the agent: use `--in-text` output as the checklist, fetch
+  the source abstract, and compare the claim against it.
+
+## Pairs with
+
+- `citation-management` -- format and fix the references this skill flags
+- `paper-lookup` -- fetch abstracts/full text for claim-level verification
+- `peer-review` -- fold this audit into a structured review pass
+
+## References
+
+- `references/verdicts.md` -- full verdict taxonomy and interpretation
+- `references/api-endpoints.md` -- provider endpoints, limits, and polite pools
+
+## License
+
+MIT

--- a/skills/verify-citations/references/api-endpoints.md
+++ b/skills/verify-citations/references/api-endpoints.md
@@ -1,0 +1,55 @@
+# Provider API endpoints
+
+All providers used by verify-citations are keyless. Optional contact
+configuration joins the "polite pools" and raises rate limits considerably.
+
+## Configuration
+
+```bash
+export CROSSREF_EMAIL=you@example.com    # Crossref + OpenAlex polite pool
+export OPENALEX_EMAIL=you@example.com    # same pool, checked independently
+```
+
+The scripts read these (or `VERIFY_CITATIONS_EMAIL`) and append
+`mailto:` to the User-Agent (Crossref convention) / `mailto` param
+(OpenAlex, E-utilities).
+
+## Crossref
+
+- Resolve by DOI: `GET https://api.crossref.org/works/{doi}`
+- Bibliographic search: `GET https://api.crossref.org/works?query.bibliographic=<title>&rows=3&select=title,author,issued,container-title,DOI,type`
+- Retraction metadata: the work message's `update-to` / `updated-by` arrays
+  carry `{type, DOI}` pointing at the retraction notice; `type` containing
+  `retract` or `withdraw` triggers the `retracted` verdict.
+- Anonymous limit: ~50 req/s shared; polite pool is more generous and
+  preferred. 404 means "DOI unknown" (used as a not-resolved signal, not an
+  error).
+- Titles arrive as lists; issued year lives at `issued.date-parts[0][0]`.
+
+## arXiv
+
+- Atom API: `GET http://export.arxiv.org/api/query?id_list=<id>&max_results=1`
+- Accepts new-format (`2401.12345`, optional `v2`) and old-format
+  (`cs/0112017`) identifiers.
+- Response is XML (namespaced Atom); titles/authors/published year are read
+  with `xml.etree`. A missing `<entry>` element means the ID is unknown.
+- Limit: ~1 request / 3 seconds is the documented ceiling; the script's
+  `--pause` default of 1s is fine for single-ID verification, raise it for
+  bulk arXiv-only sweeps.
+
+## PubMed E-utilities
+
+- ESummary: `GET https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=<pmid>&retmode=json`
+- PMIDs are extracted from references carrying `PMID:` markers.
+- Limit: 3 req/s without an API key; `NCBI_API_KEY` is honoured by the
+  paper-lookup skill but not required here.
+- An unknown PMID comes back as a JSON `error` field inside `result`, not an
+  HTTP error status.
+
+## OpenAlex
+
+- Fallback retraction check (and future enrichment):
+  `GET https://api.openalex.org/works/doi:{doi}`
+- `is_retracted` is the boolean of interest; also carries `is_paratext`
+  (indexes/cover pages), useful for future filtering.
+- Polite pool: add `?mailto=`. Anonymous: 10 req/s ceiling.

--- a/skills/verify-citations/references/verdicts.md
+++ b/skills/verify-citations/references/verdicts.md
@@ -1,0 +1,44 @@
+# Verdict taxonomy
+
+Every verify-citations script emits the same verdict strings so reports,
+filters, and downstream tooling can switch on them directly.
+
+## The verdicts
+
+| Verdict | Emitted by | Meaning | Recommended action |
+|---|---|---|---|
+| `verified` | verify_references | The entry resolved against a provider record and the stated metadata (title similarity >= 0.85, year within 1, first-author surname match) agrees with it. | None. |
+| `metadata-mismatch` | verify_references | The entry resolved to a real work, but stated details disagree with the canonical record. | Read the mismatch reasons; fix the manuscript or confirm the intended source. |
+| `retracted` | verify_references, check_retractions | Crossref `update-to`/`updated-by` or OpenAlex `is_retracted` marks the work as retracted/withdrawn. | Remove the citation; cite the retraction notice if the fact of retraction matters. |
+| `not-found` | verify_references | The entry carried a checkable identifier or title, and every provider returned no record above the match threshold. | Hand-verify. For mainstream-looking papers this is the strongest hallucination signal; for theses/datasets/grey literature it can be a false negative of the providers. |
+| `unresolved` | both | A network or API error (HTTP status, timeout) prevented checking. | Retry later; `--pause` up if rate-limited. |
+| `skipped` | verify_references | The entry had no DOI/arXiv/PMID and its title was too short/absent to search. | Add an identifier, or check manually (books, websites, software). |
+
+## Precedence
+
+A single entry receives exactly one verdict, chosen in this order:
+
+1. `retracted` -- a retraction overrides everything else (a retracted paper
+   that matches perfectly is still removed).
+2. `metadata-mismatch` -- the work is real but misdescribed.
+3. `verified`.
+4. `not-found` / `unresolved` / `skipped` when checking could not complete.
+
+## Thresholds and their knobs
+
+- **Title similarity threshold: 0.85** (Dice coefficient over normalized
+  token sets, with a containment bonus for subtitles). Passed via
+  `compare_metadata(..., title_threshold=...)`.
+- **Year tolerance: 1** -- catches the common off-by-one (online vs print
+  year) without silently accepting wrong decades.
+- **First-author surname**: compared on the normalized surname only; initial
+  differences and name-order variants do not trigger mismatches.
+
+## False-positive and false-negative profile
+
+- `not-found` false positives: grey literature, non-English titles that were
+  transliterated, very short titles colliding below threshold.
+- `verified` false negatives: Crossref records with sparse metadata (no
+  author list) will skip that comparison rather than fail it.
+- `metadata-mismatch` high precision: it requires an actual resolution, so
+  the comparison is against a canonical record, not a guess.

--- a/skills/verify-citations/scripts/_common.py
+++ b/skills/verify-citations/scripts/_common.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Shared helpers for the verify-citations skill.
+
+Everything here is deliberately pure text processing or thin HTTP plumbing:
+no script-level argparse, no global state, and no network calls at import
+time. The verification scripts import from this module so the matching and
+verdict logic can be tested offline.
+
+Verdict taxonomy (shared by verify_references.py, check_retractions.py, and
+generate_report.py -- the report renderer switches on these exact strings):
+
+    verified          the reference resolved and the stated metadata matches
+    metadata-mismatch the reference resolved but stated details disagree
+    retracted         the resolved work has been retracted or withdrawn
+    not-found         no record anywhere despite searching every provider
+    unresolved        a network or API error prevented checking
+    skipped           the entry carried no usable identifier or title
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unicodedata
+from typing import Dict, List, Optional, Tuple
+
+try:  # pragma: no cover - exercised only without requests
+    import requests
+except ImportError:  # pragma: no cover
+    requests = None
+
+VERIFIED = "verified"
+METADATA_MISMATCH = "metadata-mismatch"
+RETRACTED = "retracted"
+NOT_FOUND = "not-found"
+UNRESOLVED = "unresolved"
+SKIPPED = "skipped"
+
+VERDICT_ORDER = [
+    RETRACTED,
+    METADATA_MISMATCH,
+    NOT_FOUND,
+    UNRESOLVED,
+    SKIPPED,
+    VERIFIED,
+]
+
+# Crossref and OpenAlex both offer a "polite pool" for requests that carry a
+# contact address; without one the anonymous pool is heavily rate limited.
+def contact_email() -> Optional[str]:
+    """Return the contact address configured for polite API pools, if any."""
+    for var in ("CROSSREF_EMAIL", "OPENALEX_EMAIL", "VERIFY_CITATIONS_EMAIL"):
+        value = os.environ.get(var)
+        if value and "@" in value:
+            return value
+    return None
+
+
+def http_headers() -> Dict[str, str]:
+    """Build polite-pool HTTP headers for Crossref/OpenAlex requests."""
+    headers = {
+        "User-Agent": "verify-citations-skill/1.0 (scientific-agent-skills)",
+        "Accept": "application/json",
+    }
+    email = contact_email()
+    if email:
+        headers["User-Agent"] += f" (mailto:{email})"
+    return headers
+
+
+def fetch_json(url: str, params: Optional[Dict] = None, timeout: int = 30) -> Dict:
+    """GET a JSON API response, raising RuntimeError with the status code."""
+    if requests is None:
+        raise RuntimeError("the 'requests' package is required for network verification")
+    response = requests.get(url, params=params or {}, headers=http_headers(), timeout=timeout)
+    if response.status_code != 200:
+        raise RuntimeError(f"HTTP {response.status_code} from {url}")
+    return response.json()
+
+
+# --------------------------------------------------------------------------
+# Identifier normalisation
+# --------------------------------------------------------------------------
+
+_DOI_PREFIXES = re.compile(
+    r"^\s*(?:https?://(?:(?:dx\.)?doi\.org|hdl\.handle\.net)/|doi:\s*|DOI:\s*)",
+)
+
+_ARXIV_NEW = re.compile(r"arxiv[:\s]*([0-9]{4}\.[0-9]{4,5})(?:v[0-9]+)?", re.IGNORECASE)
+_ARXIV_OLD = re.compile(
+    r"arxiv[:\s]*([a-z\-]+(?:\.[A-Z]{2})?/\d{7})(?:v[0-9]+)?", re.IGNORECASE
+)
+
+# A bare DOI is hard to regex generally, but the common citation forms start
+# with 10.<prefix>/<suffix> and the suffix almost never contains whitespace
+# or closing braces (BibTeX fields, JSON blobs).
+_BARE_DOI = re.compile(r"\b(10\.\d{4,9}/[^\s\"'<>|,;)\]}]+)", re.IGNORECASE)
+
+_PUBMED_ID = re.compile(r"pmid[:\s]*([0-9]{1,9})", re.IGNORECASE)
+
+
+def normalize_doi(raw: Optional[str]) -> Optional[str]:
+    """Extract and normalise a DOI from a raw reference string or field.
+
+    Strips URL prefixes, the ``doi:`` scheme, and surrounding punctuation,
+    then lower-cases the result (DOIs are case-insensitive).
+    """
+    if not raw:
+        return None
+    text = raw.strip()
+    text = _DOI_PREFIXES.sub("", text)
+    match = _BARE_DOI.search(text)
+    if not match:
+        return None
+    doi = match.group(1).rstrip(".")
+    return doi.lower()
+
+
+def extract_arxiv_id(raw: Optional[str]) -> Optional[str]:
+    """Extract an arXiv identifier (new or old format) from free text."""
+    if not raw:
+        return None
+    match = _ARXIV_NEW.search(raw) or _ARXIV_OLD.search(raw)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def extract_pmid(raw: Optional[str]) -> Optional[str]:
+    """Extract a PubMed identifier from free text."""
+    if not raw:
+        return None
+    match = _PUBMED_ID.search(raw)
+    return match.group(1) if match else None
+
+
+# --------------------------------------------------------------------------
+# Title handling
+# --------------------------------------------------------------------------
+
+_LATEX_COMMANDS = re.compile(r"\\[a-zA-Z]+\*?(\[[^\]]*\])?")
+_LATEX_BRACES = re.compile(r"[{}]")
+_MATH_MODE = re.compile(r"\$[^$]*\$")
+
+
+def normalize_title(title: Optional[str]) -> str:
+    """Fold a title (or any text) to a comparable canonical form.
+
+    Strips LaTeX math mode and command names (keeping their arguments, so
+    ``\\emph{Invariant}`` contributes ``invariant``), removes accents via
+    NFKD, drops all punctuation, lower-cases, and collapses whitespace.
+    Numbers and letters are preserved so chemical names and years survive
+    comparison.
+    """
+    if not title:
+        return ""
+    text = _MATH_MODE.sub(" ", title)
+    text = _LATEX_COMMANDS.sub(" ", text)
+    text = _LATEX_BRACES.sub("", text)
+    text = unicodedata.normalize("NFKD", text)
+    text = text.encode("ascii", "ignore").decode("ascii")
+    text = re.sub(r"[^a-z0-9\s]+", " ", text.lower())
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _token_set(text: str) -> set:
+    return {token for token in text.split() if len(token) > 1}
+
+
+def title_similarity(a: Optional[str], b: Optional[str]) -> float:
+    """Return a 0..1 similarity between two titles.
+
+    Uses the Dice coefficient over normalised token sets, which is robust to
+    punctuation, casing, and small word-order differences, and picks the best
+    of full-string and token-set comparison so subtitles do not dilute a
+    match.
+    """
+    left, right = normalize_title(a), normalize_title(b)
+    if not left or not right:
+        return 0.0
+    if left == right:
+        return 1.0
+    tokens_a, tokens_b = _token_set(left), _token_set(right)
+    if not tokens_a or not tokens_b:
+        return 0.0
+    overlap = len(tokens_a & tokens_b)
+    dice = 2.0 * overlap / (len(tokens_a) + len(tokens_b))
+    # Subtitle handling: when the shorter title's tokens are fully contained
+    # in the longer one, the shorter is a prefix/subtitle of the longer.
+    # Containment alone (smaller/larger) would under-credit here -- a 5-token
+    # title inside a 7-token title is still a match -- so containment is
+    # converted to a bounded boost above the 0.85 threshold.
+    if tokens_a <= tokens_b or tokens_b <= tokens_a:
+        smaller = min(len(tokens_a), len(tokens_b))
+        larger = max(len(tokens_a), len(tokens_b))
+        return max(dice, 0.85 + 0.15 * smaller / larger)
+    return dice
+
+
+# --------------------------------------------------------------------------
+# Metadata comparison
+# --------------------------------------------------------------------------
+
+def extract_year(*texts: Optional[str]) -> Optional[int]:
+    """Pull the first plausible 4-digit publication year out of free text.
+
+    Rejects years before 1500 (page numbers, section numbers) and the far
+    future, which keeps arXiv IDs and DOIs from being mistaken for years.
+    """
+    current = 2100
+    for text in texts:
+        if not text:
+            continue
+        for match in re.finditer(r"\b(1[5-9]\d{2}|20\d{2})\b", text):
+            year = int(match.group(1))
+            if year <= current:
+                return year
+    return None
+
+
+def _first_surname(author_field: Optional[str]) -> Optional[str]:
+    """Return the first author's surname from common citation formats."""
+    if not author_field:
+        return None
+    first = re.split(r";|\band\b|&|,", author_field)[0].strip()
+    if not first:
+        return None
+    # "Jumper, John" -> Jumper ; "John Jumper" -> Jumper
+    if "," in first:
+        return normalize_title(first.split(",")[0])
+    parts = first.split()
+    return normalize_title(parts[-1]) if parts else None
+
+
+def _resolved_surname(message: Dict) -> Optional[str]:
+    """Pull the first author surname from a Crossref/OpenAlex-style record."""
+    authors = message.get("author") or message.get("authorships") or []
+    for author in authors:
+        name = author.get("family") or author.get("display_name")
+        raw = author.get("raw_author_name") if not name else None
+        candidate = name or raw
+        if candidate:
+            return normalize_title(candidate.split(",")[0])
+    return None
+
+
+def compare_metadata(
+    stated: Dict,
+    resolved: Dict,
+    title_threshold: float = 0.85,
+    year_tolerance: int = 1,
+) -> List[str]:
+    """Compare a stated reference against a resolved provider record.
+
+    Returns a list of human-readable mismatch reasons; an empty list means
+    the stated details agree with the source. ``stated`` uses citation-style
+    keys (title/year/authors), ``resolved`` uses Crossref-style keys.
+    """
+    reasons: List[str] = []
+
+    stated_title = stated.get("title")
+    resolved_title = resolved.get("title")
+    if isinstance(resolved_title, list):  # Crossref stores titles as lists
+        resolved_title = resolved_title[0] if resolved_title else None
+
+    if stated_title and resolved_title:
+        score = title_similarity(stated_title, resolved_title)
+        if score < title_threshold:
+            reasons.append(
+                f"title mismatch (similarity {score:.2f} < {title_threshold}): "
+                f"stated {stated_title!r} vs resolved {resolved_title!r}"
+            )
+
+    stated_year = extract_year(stated.get("year") or "")
+    resolved_year = extract_year(str(resolved.get("year") or ""))
+    if stated_year and resolved_year and abs(stated_year - resolved_year) > year_tolerance:
+        reasons.append(
+            f"year mismatch: stated {stated_year} vs resolved {resolved_year}"
+        )
+
+    stated_author = _first_surname(stated.get("authors"))
+    resolved_author = _resolved_surname(resolved)
+    if stated_author and resolved_author and stated_author != resolved_author:
+        reasons.append(
+            f"first-author mismatch: stated {stated_author!r} vs "
+            f"resolved {resolved_author!r}"
+        )
+
+    return reasons

--- a/skills/verify-citations/scripts/check_retractions.py
+++ b/skills/verify-citations/scripts/check_retractions.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Standalone retraction sweep for a list of DOIs.
+
+Useful on its own (a quick pre-submission hygiene pass over an existing
+.bib or reference list) and as the retraction half of the verify-citations
+workflow. Sources, in order:
+
+    1. Crossref /works/{doi} -- `update-to` / `updated-by` metadata carries
+       the official retraction notice (type "retraction" or "withdrawal").
+    2. OpenAlex /works/doi:{doi} -- the `is_retracted` boolean, which also
+       covers some withdrawals Crossref models differently.
+
+Output: one JSON object per DOI with verdict `retracted`, `clear`, or
+`unresolved` (network/API trouble), plus the notice description when found.
+
+Reads DOIs from: a references JSON (parse_references.py / verify_references.py
+output), a plain .txt/.bib file (every DOI-looking token is picked up), or
+`--doi` flags. All providers are keyless.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _common import fetch_json, normalize_doi  # noqa: E402
+
+CROSSREF_WORKS = "https://api.crossref.org/works"
+OPENALEX_WORKS = "https://api.openalex.org/works"
+
+RETRACTED = "retracted"
+CLEAR = "clear"
+UNRESOLVED = "unresolved"
+
+
+def _crossref_retraction(doi: str) -> Optional[Dict]:
+    payload = fetch_json(f"{CROSSREF_WORKS}/{doi}")
+    message = payload.get("message", {})
+    for key in ("update-to", "updated-by"):
+        for update in message.get(key) or []:
+            update_type = str(update.get("type", "")).lower()
+            if "retract" in update_type or "withdraw" in update_type:
+                return {
+                    "source": "crossref",
+                    "kind": update_type,
+                    "notice_doi": update.get("DOI"),
+                    "detail": f"Crossref {key} marks this work as {update_type}",
+                }
+    return None
+
+
+def _openalex_retraction(doi: str) -> Optional[Dict]:
+    payload = fetch_json(f"{OPENALEX_WORKS}/doi:{doi}", params={"mailto": ""})
+    if payload.get("is_retracted"):
+        return {
+            "source": "openalex",
+            "kind": "retracted",
+            "notice_doi": None,
+            "detail": "OpenAlex flags this work as retracted",
+        }
+    return None
+
+
+def check_doi(doi: str) -> Dict:
+    """Check one DOI against Crossref, then OpenAlex as a fallback."""
+    result: Dict = {"doi": doi, "verdict": CLEAR, "detail": None}
+    errors: List[str] = []
+    for checker in (_crossref_retraction, _openalex_retraction):
+        try:
+            finding = checker(doi)
+        except RuntimeError as error:
+            errors.append(str(error))
+            continue
+        if finding:
+            result["verdict"] = RETRACTED
+            result["detail"] = finding["detail"]
+            result["source"] = finding["source"]
+            result["notice_doi"] = finding["notice_doi"]
+            return result
+        # A clean answer from a provider is enough; only move to the next
+        # provider if this one could not decide (e.g. DOI unknown there).
+        result["checked_by"] = checker.__name__.replace("_retraction", "")
+        return result
+    result["verdict"] = UNRESOLVED
+    result["detail"] = "; ".join(errors) or "no provider answered"
+    return result
+
+
+def collect_dois(inputs: List[str], doi_flags: List[str]) -> List[str]:
+    """Pull DOIs from JSON payloads, text files, and --doi flags."""
+    dois: List[str] = list(doi_flags)
+    seen = set(doi_flags)
+    for raw in inputs:
+        path = Path(raw)
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if path.suffix == ".json":
+            payload = json.loads(text)
+            items = payload.get("references", payload) if isinstance(payload, dict) else payload
+            for item in items:
+                doi = normalize_doi(item.get("doi") or item.get("raw", ""))
+                if doi and doi not in seen:
+                    seen.add(doi)
+                    dois.append(doi)
+        else:
+            for match in re.finditer(r"10\.\d{4,9}/[^\s\"'<>|,;)\]}]+", text):
+                doi = normalize_doi(match.group(0))
+                if doi and doi not in seen:
+                    seen.add(doi)
+                    dois.append(doi)
+    return dois
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check DOIs for retraction status via Crossref (update-to) "
+        "and OpenAlex (is_retracted)."
+    )
+    parser.add_argument(
+        "inputs", nargs="*",
+        help="references JSON or .bib/.txt files to sweep DOIs from",
+    )
+    parser.add_argument("--doi", action="append", default=[],
+                        help="a DOI to check (repeatable)")
+    parser.add_argument("--pause", type=float, default=1.0,
+                        help="seconds between provider calls (default 1.0)")
+    parser.add_argument("--output", help="write JSON here instead of stdout")
+    args = parser.parse_args(argv)
+
+    dois = collect_dois(args.inputs, args.doi)
+    if not dois:
+        parser.error("no DOIs found; pass files or --doi flags")
+
+    results = []
+    for index, doi in enumerate(dois):
+        results.append(check_doi(doi))
+        if index + 1 < len(dois):
+            time.sleep(args.pause)
+
+    counts: Dict[str, int] = {}
+    for item in results:
+        counts[item["verdict"]] = counts.get(item["verdict"], 0) + 1
+
+    rendered = json.dumps({"checked": len(results), "verdict_counts": counts,
+                           "results": results}, indent=2)
+    if args.output:
+        Path(args.output).write_text(rendered + "\n", encoding="utf-8")
+        print(f"checked {len(results)} DOIs: {counts} -> {args.output}")
+    else:
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/verify-citations/scripts/generate_report.py
+++ b/skills/verify-citations/scripts/generate_report.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Render a citation-audit report from the verify-citations workflow outputs.
+
+Merges the JSON emitted by verify_references.py (and optionally
+check_retractions.py) into a single markdown report a human can act on:
+
+    - a summary table with the verdict counts and a coverage percentage
+    - flagged references grouped by verdict, worst first (retracted,
+      metadata-mismatch, not-found, unresolved)
+    - the full reference table for the record
+
+Pure text processing: no network access, so it works offline on saved JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from _common import (  # noqa: E402
+    METADATA_MISMATCH,
+    NOT_FOUND,
+    RETRACTED,
+    SKIPPED,
+    UNRESOLVED,
+    VERIFIED,
+    VERDICT_ORDER,
+)
+
+# Report groups worst-first; verified entries collapse into a summary count.
+FLAGGED_ORDER = [RETRACTED, METADATA_MISMATCH, NOT_FOUND, UNRESOLVED]
+
+_VERDICT_GLYPH = {
+    VERIFIED: "[ok]",
+    METADATA_MISMATCH: "[!]",
+    RETRACTED: "[X]",
+    NOT_FOUND: "[?]",
+    UNRESOLVED: "[~]",
+    SKIPPED: "[-]",
+}
+
+_VERDICT_EXPLANATION = {
+    VERIFIED: "resolved and the stated metadata matches the source",
+    METADATA_MISMATCH: "resolved, but stated details disagree with the source -- "
+    "check the paper is the one you meant to cite",
+    RETRACTED: "the work has been retracted or withdrawn -- remove it",
+    NOT_FOUND: "no provider knows this work -- a prime hallucination suspect",
+    UNRESOLVED: "network or API error prevented checking -- retry later",
+    SKIPPED: "nothing to check (no identifier and no title)",
+}
+
+
+def _short(text: Optional[str], limit: int = 70) -> str:
+    if not text:
+        return "--"
+    text = " ".join(str(text).split())
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def summarize(results: List[Dict]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for item in results:
+        counts[item.get("verdict", SKIPPED)] = counts.get(item.get("verdict", SKIPPED), 0) + 1
+    return counts
+
+
+def render_report(results: List[Dict], title: str = "Citation audit") -> str:
+    """Render the markdown audit report for verified reference results."""
+    counts = summarize(results)
+    total = len(results)
+    lines: List[str] = [f"# {title}", ""]
+
+    if total:
+        good = counts.get(VERIFIED, 0)
+        checkable = total - counts.get(SKIPPED, 0)
+        coverage = (100.0 * good / checkable) if checkable else 0.0
+        lines += [
+            f"**References checked:** {total} · "
+            f"**verified:** {good} · **coverage:** {coverage:.0f}% of checkable entries",
+            "",
+        ]
+    else:
+        lines += ["No references were supplied or extracted.", ""]
+        return "\n".join(lines)
+
+    lines += ["## Verdict counts", "", "| Verdict | Count | Meaning |", "|---|---|---|"]
+    for verdict in VERDICT_ORDER:
+        if counts.get(verdict):
+            lines.append(
+                f"| {_VERDICT_GLYPH[verdict]} {verdict} | {counts[verdict]} "
+                f"| {_VERDICT_EXPLANATION[verdict]} |"
+            )
+    lines.append("")
+
+    flagged_any = False
+    for verdict in FLAGGED_ORDER:
+        group = [item for item in results if item.get("verdict") == verdict]
+        if not group:
+            continue
+        flagged_any = True
+        lines += [f"## {verdict} ({len(group)})", ""]
+        for item in group:
+            label = item.get("title") or item.get("raw") or item.get("key", "?")
+            lines.append(f"### {_VERDICT_GLYPH[verdict]} {_short(label)}")
+            lines.append(f"- position/key: `{item.get('key', '?')}`")
+            if item.get("doi"):
+                lines.append(f"- stated DOI: `{item['doi']}`")
+            if item.get("matched_via"):
+                lines.append(f"- resolved via: {item['matched_via']}")
+            if item.get("resolved", {}).get("title"):
+                lines.append(f"- resolved title: {_short(item['resolved']['title'])}")
+            if item.get("resolved", {}).get("year") is not None:
+                lines.append(f"- resolved year: {item['resolved']['year']}")
+            for reason in item.get("mismatch_reasons", []):
+                lines.append(f"- mismatch: {reason}")
+            if item.get("retraction_detail"):
+                lines.append(f"- retraction: {item['retraction_detail']}")
+            if item.get("detail"):
+                lines.append(f"- detail: {item['detail']}")
+            lines.append("")
+
+    if flagged_any:
+        lines += [
+            "> Verdicts are evidence, not judgement: a metadata mismatch is often "
+            "a typo in the manuscript, and a not-found result for a genuinely "
+            "obscure document (theses, datasets, grey literature) can be a false "
+            "positive. Verify flagged items by hand before removing them.",
+            "",
+        ]
+
+    lines += ["## All references", "",
+              "| # | Verdict | Stated title | Resolved | Year |",
+              "|---|---|---|---|---|"]
+    for index, item in enumerate(results, start=1):
+        resolved_title = _short(item.get("resolved", {}).get("title"), 40)
+        year = item.get("resolved", {}).get("year", item.get("year", ""))
+        glyph = _VERDICT_GLYPH.get(item.get("verdict"), "?")
+        lines.append(
+            f"| {index} | {glyph} {item.get('verdict', '?')} "
+            f"| {_short(item.get('title') or item.get('raw'))} "
+            f"| {resolved_title} | {year if year else '--'} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _load_results(path: Path) -> List[Dict]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict):
+        return payload.get("references", [])
+    return payload
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render a markdown citation-audit report from "
+        "verify_references.py JSON output (offline)."
+    )
+    parser.add_argument("verification", help="JSON output from verify_references.py")
+    parser.add_argument("--title", default="Citation audit", help="report heading")
+    parser.add_argument("--output", help="write markdown here instead of stdout")
+    args = parser.parse_args(argv)
+
+    path = Path(args.verification)
+    if not path.is_file():
+        parser.error(f"not a file: {path}")
+
+    results = _load_results(path)
+    report = render_report(results, title=args.title)
+    if args.output:
+        Path(args.output).write_text(report, encoding="utf-8")
+        counts = summarize(results)
+        print(f"report written -> {args.output} (verdicts: {counts})")
+    else:
+        print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/verify-citations/scripts/parse_references.py
+++ b/skills/verify-citations/scripts/parse_references.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Extract a structured reference list (and in-text citations) from a manuscript.
+
+Supported inputs, auto-detected or forced with --format:
+
+    markdown   numbered or bulleted reference sections in a .md / .txt file
+    latex      \\bibitem entries, \\begin{thebibliography}, or inline \\cite keys
+    bibtex     a .bib file (brace-depth parser, comment-safe)
+
+Outputs a JSON list of reference candidates, each carrying whatever
+identifiers could be recovered (DOI, arXiv ID, PMID, title, authors, year,
+position). The downstream verifier only needs one identifier or a title to
+work, so extraction is intentionally permissive: a partially parsed entry is
+more useful than a dropped one.
+
+Also extracts in-text citation sentences (--in-text) so claims can later be
+checked against the source they cite.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _common import extract_arxiv_id, extract_pmid, normalize_doi  # noqa: E402
+
+REFERENCE_HEADINGS = re.compile(
+    r"^\s*(?:#+\s*)?(?:references|bibliography|works cited|literature cited)"
+    r"\s*:?\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+_ENTRY_PREFIX = re.compile(r"^\s*(?:\[\d+\]|\(\d+\)|\d+[.)])\s*")
+_TEX_BIBITEM = re.compile(r"\\bibitem(?:\[[^\]]*\])?\{?([^}\n]*)\}?\s*\n?")
+_TEX_COMMENT = re.compile(r"(?m)^%.*$")
+
+# A sentence that carries an in-text citation marker and something checkable
+# (a number or a quoted phrase).
+_NUMERIC_CLAIM = re.compile(r"\d+(?:\.\d+)?\s*%|\b\d+(?:\.\d+)?\b")
+_QUOTED_CLAIM = re.compile(r"[\"“][^\"”]{8,}[\"”]")
+
+_CITE_MARKERS = re.compile(
+    r"(?P<bracket>\[\d+(?:\s*[,;–-]\s*\d+)*\])|(?P<paren>\(\d+(?:\s*[,;]\s*\d+)*\))"
+    r"|(?P<author>[\w\-]+\s+et\s+al\.?,?\s+\(?\d{4}\)?)",
+)
+
+
+# --------------------------------------------------------------------------
+# BibTeX
+# --------------------------------------------------------------------------
+
+def parse_bibtex(text: str) -> List[Dict]:
+    """Parse BibTeX entries with a brace-depth scanner.
+
+    Handles multi-line values, nested braces in titles, and comments between
+    entries; single-line entries are recognised because depth, not newlines,
+    closes them.
+    """
+    entries: List[Dict] = []
+    index = 0
+    length = len(text)
+    while index < length:
+        at = text.find("@", index)
+        if at == -1:
+            break
+        header = re.match(r"@(\w+)\s*\{", text[at:])
+        if not header:
+            index = at + 1
+            continue
+        kind = header.group(1).lower()
+        if kind in ("comment", "preamble", "string"):
+            index = at + header.end()
+            continue
+        body_start = at + header.end()
+        depth, cursor = 1, body_start
+        while cursor < length and depth:
+            if text[cursor] == "{":
+                depth += 1
+            elif text[cursor] == "}":
+                depth -= 1
+            cursor += 1
+        if depth:  # unbalanced entry; take what is there
+            cursor = length
+        body = text[body_start:cursor - 1]
+        key_match = re.match(r"\s*([^,\s]+)\s*,", body)
+        entry: Dict = {
+            "key": key_match.group(1) if key_match else "",
+            "type": kind,
+            "raw": body.strip(),
+        }
+        fields: Dict[str, str] = {}
+        for field_match in re.finditer(
+            r"(\w+)\s*=\s*(\{.*?\}|\".*?\")\s*(?:,|$)", body, re.DOTALL
+        ):
+            name = field_match.group(1).lower()
+            value = field_match.group(2)
+            if value.startswith("{") or value.startswith('"'):
+                value = value[1:-1]
+            fields[name] = re.sub(r"\s+", " ", value).strip()
+        entry["fields"] = fields
+        entries.append(_entry_from_fields(entry))
+        index = cursor
+    return entries
+
+
+# --------------------------------------------------------------------------
+# Field assembly
+# --------------------------------------------------------------------------
+
+def _entry_from_fields(entry: Dict) -> Dict:
+    fields = entry.get("fields", {})
+    title = fields.get("title", "")
+    authors = fields.get("author", "")
+    year_source = fields.get("year", "") or fields.get("date", "")
+    blob = " ".join([title, authors, fields.get("journal", ""), fields.get("doi", ""),
+                     fields.get("url", ""), fields.get("eprint", ""), entry.get("raw", "")])
+    candidate = {
+        "key": entry.get("key", ""),
+        "type": entry.get("type", ""),
+        "title": title,
+        "authors": authors,
+        "year": year_source,
+        "doi": normalize_doi(fields.get("doi", "") or blob),
+        # An eprint field carries the bare arXiv number without the arXiv
+        # prefix the extractor looks for, so prepend it for that field only.
+        "arxiv_id": extract_arxiv_id(
+            "arxiv " + (fields.get("eprint", "") or "")
+        ) or extract_arxiv_id(fields.get("url", "") or blob),
+        "pmid": extract_pmid(fields.get("pmid", "") or fields.get("note", "") or blob),
+    }
+    return candidate
+
+
+def _entry_from_text(raw: str, position: int) -> Dict:
+    """Build a reference candidate from a free-text reference string."""
+    text = re.sub(r"\s+", " ", raw).strip()
+    doi = normalize_doi(text)
+    arxiv_id = extract_arxiv_id(text)
+    pmid = extract_pmid(text)
+
+    title = _extract_title_from_text(text)
+    authors = ""
+    year = ""
+    year_match = re.search(r"\(?((?:19|20)\d{2})\)?", text)
+    if year_match:
+        year = year_match.group(1)
+        before_year = text[:year_match.start()].strip()
+        # Author block conventionally sits before the year, before the title.
+        authors = re.split(r"[.:]|\s{2,}", before_year)[0].strip(" .,")
+    return {
+        "key": str(position),
+        "type": "text",
+        "title": title or "",
+        "authors": authors,
+        "year": year,
+        "doi": doi,
+        "arxiv_id": arxiv_id,
+        "pmid": pmid,
+        "raw": text,
+    }
+
+
+def _extract_title_from_text(text: str) -> str:
+    """Best-effort title extraction from a free-text reference.
+
+    The dominant convention in numbered reference lists is
+    ``Authors (Year). Title. Venue.`` so the primary strategy takes the
+    sentence following the year marker. Quoted titles, markdown italics, and
+    (for yearless references) the first substantial sentence serve as
+    fallbacks.
+    """
+    quoted = re.search(r"[\"“]([^\"”]{12,})[\"”]", text)
+    italic = re.search(r"\*([^*]{12,})\*", text)
+
+    # Primary: the sentence right after the year (covers "(2017)." and
+    # "2017." and "(2017a)." variants).
+    after_year = re.search(
+        r"\(?((?:19|20)\d{2})[a-z]?\)?\s*\.\s*([A-Z\"“].+?)(?=\.\s+[A-Z\"“]|\.$|$)",
+        text,
+    )
+    if after_year:
+        candidate = after_year.group(2).strip(" .,")
+        if len(candidate.split()) >= 3:
+            return candidate
+
+    # Fallbacks.
+    if quoted:
+        return quoted.group(1).strip(" .,")
+    if italic:
+        return italic.group(1).strip(" .,")
+    sentences = [s for s in re.split(r"(?<=[.?!])\s+", text) if len(s.split()) >= 3]
+    return sentences[0].strip(" .,") if sentences else ""
+
+
+# --------------------------------------------------------------------------
+# Document segmentation
+# --------------------------------------------------------------------------
+
+def _split_reference_block(block: str) -> List[str]:
+    """Split a reference section into entries.
+
+    Prefers explicit numbering; falls back to blank-line separation; falls
+    back further to one-entry-per-line for hanging-indent styles.
+    """
+    lines = block.splitlines()
+    entries: List[str] = []
+    current: List[str] = []
+
+    numbered = re.compile(r"^\s*(?:\[\d+\]|\(\d+\)|\d+[.)])\s+")
+    if sum(1 for line in lines if numbered.match(line)) >= 2:
+        for line in lines:
+            if numbered.match(line):
+                if current:
+                    entries.append(" ".join(current))
+                    current = []
+            current.append(line)
+        if current:
+            entries.append(" ".join(current))
+        return [e for e in entries if e.strip()]
+
+    paragraphs = re.split(r"\n\s*\n", block)
+    paragraphs = [re.sub(r"\s+", " ", p).strip() for p in paragraphs if p.strip()]
+    if len(paragraphs) >= 2:
+        return paragraphs
+    return [re.sub(r"\s+", " ", line).strip() for line in lines if line.strip()]
+
+
+def parse_markdown(text: str) -> List[Dict]:
+    """Extract references from a markdown/plain-text manuscript."""
+    heading = REFERENCE_HEADINGS.search(text)
+    if heading:
+        block = text[heading.end():]
+        # Stop at the next top-level heading after the reference section.
+        next_heading = re.search(r"^#{1,2}\s+(?!.*references)", block, re.IGNORECASE | re.MULTILINE)
+        if next_heading:
+            block = block[:next_heading.start()]
+    else:
+        # No heading: treat the whole document and let entry patterns decide.
+        block = text
+    raw_entries = _split_reference_block(block)
+    entries = []
+    for position, raw in enumerate(raw_entries, start=1):
+        cleaned = _ENTRY_PREFIX.sub("", raw)
+        if len(cleaned.split()) < 4:
+            continue  # too short to be a reference (stray headers, URLs)
+        entries.append(_entry_from_text(cleaned, position))
+    return entries
+
+
+def parse_latex(text: str) -> List[Dict]:
+    """Extract references from a LaTeX document (\\bibitem entries).
+
+    ``\\bibitem[label]{key}`` and bare ``\\bibitem{key}`` are both handled;
+    each item's body runs to the next \\bibitem or the end of the document.
+    """
+    text = _TEX_COMMENT.sub("", text)
+    matches = list(_TEX_BIBITEM.finditer(text))
+    entries: List[Dict] = []
+    for index, match in enumerate(matches):
+        label = (match.group(1) or "").strip()
+        body_start = match.end()
+        body_end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        raw = re.sub(r"\s+", " ", text[body_start:body_end]).strip()
+        # Render common LaTeX markup down to plain text: \emph{x} -> x.
+        raw = re.sub(r"\\[a-zA-Z]+\*?(\[[^\]]*\])?(\{([^{}]*)\})?", r"\3", raw)
+        raw = re.sub(r"[{}~]", " ", raw)
+        if len(raw.split()) < 4:
+            continue
+        entry = _entry_from_text(raw, len(entries) + 1)
+        if label:
+            entry["key"] = label
+        entries.append(entry)
+    return entries
+
+
+# --------------------------------------------------------------------------
+# In-text citation extraction
+# ---------------------------------------------------------------------------
+
+def extract_in_text_citations(text: str) -> List[Dict]:
+    """Pull checkable sentences with citation markers out of a manuscript.
+
+    Returns sentences that carry a numeric/bracketed marker or an
+    author-year mention AND at least one verifiable element (a statistic or
+    a quoted phrase). Verifier scripts join these to reference entries by
+    marker or by key.
+    """
+    sentences = re.split(r"(?<=[.!?])\s+(?=[A-Z\"“])", re.sub(r"\s+", " ", text))
+    found: List[Dict] = []
+    for sentence in sentences:
+        if not (_NUMERIC_CLAIM.search(sentence) or _QUOTED_CLAIM.search(sentence)):
+            continue
+        markers: List[str] = []
+        for match in _CITE_MARKERS.finditer(sentence):
+            marker = match.group("bracket") or match.group("paren") or match.group("author")
+            if marker:
+                markers.append(marker.strip())
+        if not markers:
+            continue
+        quote = _QUOTED_CLAIM.search(sentence)
+        found.append(
+            {
+                "sentence": sentence.strip(),
+                "markers": markers,
+                "quote": quote.group(0).strip("\"“”") if quote else None,
+            }
+        )
+    return found
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+def detect_format(path: Path, forced: Optional[str] = None) -> str:
+    if forced:
+        return forced
+    suffix = path.suffix.lower()
+    if suffix == ".bib":
+        return "bibtex"
+    if suffix in (".tex",):
+        return "latex"
+    if suffix in (".md", ".markdown", ".txt"):
+        return "markdown"
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if "\\bibitem" in text or "\\begin{thebibliography}" in text:
+        return "latex"
+    if "@" in text and re.search(r"@\w+\s*\{", text):
+        return "bibtex"
+    return "markdown"
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Extract a structured reference list from a manuscript "
+        "(markdown, LaTeX, or BibTeX) as JSON for verify_references.py."
+    )
+    parser.add_argument("manuscript", help="path to the manuscript (.md/.tex) or bibliography (.bib)")
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "latex", "bibtex"],
+        default=None,
+        help="force a parser instead of detecting from the filename",
+    )
+    parser.add_argument(
+        "--in-text",
+        action="store_true",
+        help="also extract checkable in-text citation sentences (markdown/latex inputs)",
+    )
+    parser.add_argument("--output", help="write JSON here instead of stdout")
+    args = parser.parse_args(argv)
+
+    path = Path(args.manuscript)
+    if not path.is_file():
+        parser.error(f"not a file: {path}")
+    fmt = detect_format(path, args.format)
+    text = path.read_text(encoding="utf-8", errors="replace")
+
+    if fmt == "bibtex":
+        references = parse_bibtex(text)
+    elif fmt == "latex":
+        references = parse_latex(text)
+    else:
+        references = parse_markdown(text)
+
+    payload: Dict = {"format": fmt, "source": str(path), "count": len(references),
+                     "references": references}
+    if args.in_text and fmt != "bibtex":
+        payload["in_text_citations"] = extract_in_text_citations(text)
+
+    rendered = json.dumps(payload, indent=2, ensure_ascii=False)
+    if args.output:
+        Path(args.output).write_text(rendered + "\n", encoding="utf-8")
+        print(f"parsed {len(references)} references ({fmt}) -> {args.output}")
+    else:
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/verify-citations/scripts/verify_references.py
+++ b/skills/verify-citations/scripts/verify_references.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Verify manuscript references against live bibliographic databases.
+
+Takes the JSON produced by parse_references.py (or parses the manuscript
+itself when given the document path directly) and resolves every entry:
+
+    1. DOI present        -> Crossref /api/works/{doi}
+    2. arXiv ID present   -> arXiv Atom API
+    3. PMID present       -> PubMed E-utilities esummary
+    4. title only         -> Crossref bibliographic search, best similarity wins
+
+Each reference gets one of the shared verdicts (see _common.py):
+
+    verified | metadata-mismatch | retracted | not-found | unresolved | skipped
+
+`metadata-mismatch` entries resolved fine but disagree with what the
+manuscript states (wrong year, wrong first author, garbled title) -- the
+signature of an LLM-hallucinated or hand-mangled citation that nonetheless
+points at a real paper. `not-found` means no provider knows the work at all.
+
+Retraction status is checked in the same pass when Crossref supplies an
+`update-to`/`updated-by` record (check_retractions.py does the standalone
+sweep for already-known DOI lists).
+
+All providers are keyless; set CROSSREF_EMAIL / OPENALEX_EMAIL to join the
+polite pools and avoid anonymous rate limits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Dict, List, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _common import (  # noqa: E402
+    METADATA_MISMATCH,
+    NOT_FOUND,
+    RETRACTED,
+    SKIPPED,
+    UNRESOLVED,
+    VERIFIED,
+    compare_metadata,
+    contact_email,
+    extract_year,
+    fetch_json,
+    title_similarity,
+)
+
+CROSSREF_WORKS = "https://api.crossref.org/works"
+CROSSREF_SEARCH = "https://api.crossref.org/works"
+ARXIV_API = "http://export.arxiv.org/api/query"
+PUBMED_ESUMMARY = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
+
+MATCH_THRESHOLD = 0.85
+SEARCH_ROWS = 3
+REQUEST_PAUSE = 1.0  # seconds between provider calls; keeps anonymous pools happy
+
+
+def _crossref_record(message: Dict) -> Dict:
+    """Normalise a Crossref message into the resolver's record shape."""
+    titles = message.get("title") or []
+    year = None
+    for key in ("issued", "published-print", "published-online"):
+        parts = (message.get(key) or {}).get("date-parts") or []
+        if parts and parts[0] and parts[0][0]:
+            year = parts[0][0]
+            break
+    return {
+        "title": titles[0] if titles else None,
+        "year": year,
+        "author": message.get("author") or [],
+        "container": (message.get("container-title") or [None])[0],
+        "doi": (message.get("DOI") or "").lower() or None,
+        "type": message.get("type"),
+    }
+
+
+def _retraction_reason(message: Dict) -> Optional[str]:
+    """Return a description if the Crossref record marks a retraction."""
+    for key in ("update-to", "updated-by"):
+        for update in message.get(key) or []:
+            update_type = str(update.get("type", "")).lower()
+            if "retract" in update_type or "withdraw" in update_type:
+                return f"{key}: {update_type} ({update.get('DOI', 'unknown DOI')})"
+    return None
+
+
+def _fetch_by_doi(doi: str) -> Optional[Dict]:
+    try:
+        payload = fetch_json(f"{CROSSREF_WORKS}/{doi}")
+    except RuntimeError as error:
+        if "HTTP 404" in str(error):
+            return None
+        raise
+    message = payload.get("message", {})
+    record = _crossref_record(message)
+    record["_retraction"] = _retraction_reason(message)
+    return record
+
+
+def _search_crossref(title: str) -> List[Dict]:
+    params = {
+        "query.bibliographic": title,
+        "rows": SEARCH_ROWS,
+        "select": "title,author,issued,container-title,DOI,type",
+    }
+    email = contact_email()
+    if email:
+        params["mailto"] = email
+    payload = fetch_json(CROSSREF_SEARCH, params=params)
+    items = payload.get("message", {}).get("items", [])
+    return [_crossref_record(item) for item in items]
+
+
+def _fetch_arxiv(arxiv_id: str) -> Optional[Dict]:
+    """Fetch an arXiv record; the Atom API returns XML, parsed with stdlib ET."""
+    from _common import http_headers  # local import keeps the module importable offline
+
+    import requests
+
+    response = requests.get(
+        ARXIV_API,
+        params={"id_list": arxiv_id, "max_results": 1},
+        headers=http_headers(),
+        timeout=30,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(f"HTTP {response.status_code} from arXiv API")
+    root = ET.fromstring(response.text)
+    ns = {"atom": "http://www.w3.org/2005/Atom"}
+    entry = root.find("atom:entry", ns)
+    if entry is None:
+        return None
+    title_el = entry.find("atom:title", ns)
+    published_el = entry.find("atom:published", ns)
+    authors = [el.text for el in entry.findall("atom:author/atom:name", ns) if el.text]
+    year = published_el.text[:4] if published_el is not None and published_el.text else None
+    return {
+        "title": title_el.text.strip() if title_el is not None and title_el.text else None,
+        "year": int(year) if year and year.isdigit() else None,
+        "author": [{"family": name.split()[-1], "given": " ".join(name.split()[:-1])}
+                   for name in authors],
+        "container": "arXiv",
+        "doi": None,
+        "type": "preprint",
+    }
+
+
+def _fetch_pubmed(pmid: str) -> Optional[Dict]:
+    params = {
+        "db": "pubmed",
+        "id": pmid,
+        "retmode": "json",
+        "tool": "verify-citations-skill",
+    }
+    email = contact_email()
+    if email:
+        params["email"] = email
+    payload = fetch_json(PUBMED_ESUMMARY, params=params)
+    result = payload.get("result", {})
+    docsum = result.get(pmid)
+    if not docsum or "error" in docsum:
+        return None
+    authors = [
+        {"family": a.get("name", "").split(" ")[0], "given": ""}
+        for a in docsum.get("authors", []) if a.get("name")
+    ]
+    pubdate = docsum.get("pubdate", "") or docsum.get("sortpubdate", "")
+    return {
+        "title": docsum.get("title"),
+        "year": extract_year(pubdate),
+        "author": authors,
+        "container": docsum.get("source"),
+        "doi": (docsum.get("elocationid") or "").lower() or None,
+        "type": "journal-article",
+    }
+
+
+def _best_search_match(title: str) -> Optional[Dict]:
+    candidates = _search_crossref(title)
+    best, best_score = None, 0.0
+    for candidate in candidates:
+        score = title_similarity(title, candidate.get("title"))
+        if score > best_score:
+            best, best_score = candidate, score
+    if best is None or best_score < MATCH_THRESHOLD:
+        return None
+    return best
+
+
+def resolve_reference(reference: Dict) -> Dict:
+    """Resolve and verify one reference candidate. Returns an enriched copy."""
+    result = dict(reference)
+    result.setdefault("verdict", SKIPPED)
+    doi = reference.get("doi")
+    arxiv_id = reference.get("arxiv_id")
+    pmid = reference.get("pmid")
+    title = reference.get("title") or ""
+
+    if not (doi or arxiv_id or pmid or title):
+        result["verdict"] = SKIPPED
+        result["detail"] = "no identifier and no title to check"
+        return result
+
+    resolved: Optional[Dict] = None
+    matched_via = None
+    try:
+        if doi:
+            resolved = _fetch_by_doi(doi)
+            matched_via = f"crossref:doi/{doi}" if resolved else None
+        if resolved is None and arxiv_id:
+            resolved = _fetch_arxiv(arxiv_id)
+            matched_via = f"arxiv:{arxiv_id}" if resolved else None
+        if resolved is None and pmid:
+            resolved = _fetch_pubmed(pmid)
+            matched_via = f"pubmed:{pmid}" if resolved else None
+        if resolved is None and title and len(title.split()) >= 4:
+            resolved = _best_search_match(title)
+            matched_via = "crossref:search" if resolved else None
+    except RuntimeError as error:
+        result["verdict"] = UNRESOLVED
+        result["detail"] = str(error)
+        return result
+    finally:
+        time.sleep(REQUEST_PAUSE)
+
+    if resolved is None:
+        result["verdict"] = NOT_FOUND
+        result["detail"] = "no record found in any queried provider"
+        return result
+
+    result["matched_via"] = matched_via
+    result["resolved"] = {
+        "title": resolved.get("title"),
+        "year": resolved.get("year"),
+        "container": resolved.get("container"),
+        "doi": resolved.get("doi"),
+    }
+
+    retraction = resolved.get("_retraction")
+
+    mismatches = compare_metadata(
+        {"title": title, "year": reference.get("year"), "authors": reference.get("authors")},
+        resolved,
+    )
+    if retraction:
+        result["verdict"] = RETRACTED
+        result["retraction_detail"] = retraction
+    elif mismatches:
+        result["verdict"] = METADATA_MISMATCH
+        result["mismatch_reasons"] = mismatches
+    else:
+        result["verdict"] = VERIFIED
+    return result
+
+
+def verify_all(references: List[Dict], pause: float = REQUEST_PAUSE) -> List[Dict]:
+    """Verify a list of reference candidates, returning enriched copies."""
+    global REQUEST_PAUSE
+    REQUEST_PAUSE = pause
+    return [resolve_reference(reference) for reference in references]
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify parsed references against Crossref/arXiv/PubMed; "
+        "assigns verified/metadata-mismatch/retracted/not-found/unresolved/skipped."
+    )
+    parser.add_argument(
+        "input",
+        help="references JSON from parse_references.py, or a manuscript path "
+        "to parse first",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "latex", "bibtex"],
+        default=None,
+        help="parser hint when given a manuscript instead of JSON",
+    )
+    parser.add_argument("--pause", type=float, default=REQUEST_PAUSE,
+                        help="seconds between provider calls (default 1.0)")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="verify only the first N references")
+    parser.add_argument("--output", help="write JSON here instead of stdout")
+    args = parser.parse_args(argv)
+
+    path = Path(args.input)
+    if not path.is_file():
+        parser.error(f"not a file: {path}")
+
+    if path.suffix == ".json":
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        references = payload.get("references", payload) if isinstance(payload, dict) else payload
+    else:
+        from parse_references import detect_format, parse_bibtex, parse_latex, parse_markdown
+
+        fmt = detect_format(path, args.format)
+        text = path.read_text(encoding="utf-8", errors="replace")
+        references = {
+            "bibtex": parse_bibtex,
+            "latex": parse_latex,
+            "markdown": parse_markdown,
+        }[fmt](text)
+
+    if args.limit:
+        references = references[: args.limit]
+
+    verified = verify_all(references, pause=args.pause)
+
+    counts: Dict[str, int] = {}
+    for item in verified:
+        counts[item["verdict"]] = counts.get(item["verdict"], 0) + 1
+
+    rendered = json.dumps({"verified_count": len(verified), "verdict_counts": counts,
+                           "references": verified}, indent=2, ensure_ascii=False)
+    if args.output:
+        Path(args.output).write_text(rendered + "\n", encoding="utf-8")
+        print(f"verified {len(verified)} references: {counts} -> {args.output}")
+    else:
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skill-requirements.toml
+++ b/tests/skill-requirements.toml
@@ -103,6 +103,14 @@ packages = [
     "scholarly",
 ]
 
+[skills.verify-citations]
+# Parsing, normalisation, matching, and report rendering are standard library
+# (scripts/_common.py and friends). `requests` covers Crossref, arXiv (Atom
+# XML over HTTPS), PubMed E-utilities, and the OpenAlex fallback.
+packages = [
+    "requests",
+]
+
 [skills.pyzotero]
 packages = ["pyzotero", "bibtexparser", "python-dotenv"]
 

--- a/tests/verify-citations/fixtures/sample.bib
+++ b/tests/verify-citations/fixtures/sample.bib
@@ -1,0 +1,23 @@
+@article{jumper2021,
+  author = {Jumper, John and Evans, Richard},
+  title = {Highly accurate protein structure prediction with {AlphaFold}},
+  journal = {Nature},
+  year = {2021},
+  volume = {596},
+  pages = {583--589},
+  doi = {https://doi.org/10.1038/s41586-021-03819-2}
+}
+
+% a comment between entries
+
+@inproceedings{vaswani2017,
+  author = {Vaswani, Ashish and Shazeer, Noam},
+  title = {"Attention Is All You Need"},
+  booktitle = {NeurIPS},
+  year = {2017},
+  eprint = {1706.03762},
+  archivePrefix = {arXiv}
+}
+
+@misc{singleline,
+  title = {A Single Line Entry}, year = {2020}, doi = {10.1000/xyz123}}

--- a/tests/verify-citations/fixtures/sample_manuscript.md
+++ b/tests/verify-citations/fixtures/sample_manuscript.md
@@ -1,0 +1,25 @@
+# Sample Manuscript: VLM-Based Foul Severity Classification
+
+## Abstract
+
+We classify football fouls with a compact vision-language model. Prior work
+reports referee agreement of only 0.21 kappa "severity is a distribution, not
+a label" [1]. The MVFoul winner reached 44.76 combined balanced accuracy [2].
+Attention remains the backbone of our text encoder [3].
+
+## Method
+
+Details of the method.
+
+## References
+
+[1] Held, L. et al. (2025). VARS: Video Assistant Referee System. Journal of
+Sports Analytics. https://doi.org/10.1080/24733938.2025.1234567
+
+[2] WJB Team (2025). Multi-view foul detection in broadcast soccer video.
+ACM MMSports.
+
+[3] Vaswani, A., Shazeer, N., Parmar, N. (2017). Attention Is All You Need.
+Advances in Neural Information Processing Systems. arXiv:1706.03762
+
+[4] Smith, J. (2022). Quantum leverage in protein folding. Nature.

--- a/tests/verify-citations/test_scripts.py
+++ b/tests/verify-citations/test_scripts.py
@@ -1,0 +1,339 @@
+"""Tests for the verify-citations skill.
+
+The network-facing half (Crossref/arXiv/PubMed/OpenAlex) cannot run in CI;
+the value of the skill, though, is concentrated in the pure half this suite
+drives: extracting references from real manuscripts without losing or
+merging entries, normalising identifiers so lookups do not silently miss,
+scoring title matches so a subtitle does not split a citation in two, and
+rendering verdicts a human can act on. Network paths are exercised only as
+far as argument validation and the no-identifier skip verdict.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+import skill_contract
+
+SKILL_ROOT = Path(__file__).resolve().parents[2] / "skills" / "verify-citations"
+SCRIPTS = SKILL_ROOT / "scripts"
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+sys.path.insert(0, str(SCRIPTS))
+
+import _common  # noqa: E402
+import check_retractions  # noqa: E402
+import generate_report  # noqa: E402
+import parse_references  # noqa: E402
+import verify_references  # noqa: E402
+
+CliHelpTests = skill_contract.cli.help_test_case(SKILL_ROOT)
+
+
+class IdentifierNormalisationTests(unittest.TestCase):
+    def test_doi_url_prefixes_are_stripped(self) -> None:
+        for raw in (
+            "https://doi.org/10.1038/s41586-021-03819-2",
+            "http://dx.doi.org/10.1038/s41586-021-03819-2",
+            "doi: 10.1038/s41586-021-03819-2",
+            "DOI:10.1038/S41586-021-03819-2",
+        ):
+            with self.subTest(raw=raw):
+                self.assertEqual(
+                    _common.normalize_doi(raw), "10.1038/s41586-021-03819-2"
+                )
+
+    def test_bare_doi_is_found_inside_text(self) -> None:
+        text = "Nature 596, 583-589 (2021). 10.1038/s41586-021-03819-2"
+        self.assertEqual(
+            _common.normalize_doi(text), "10.1038/s41586-021-03819-2"
+        )
+
+    def test_trailing_sentence_punctuation_is_not_part_of_the_doi(self) -> None:
+        self.assertEqual(
+            _common.normalize_doi("Nature. 10.1038/s41586-021-03819-2."),
+            "10.1038/s41586-021-03819-2",
+        )
+
+    def test_a_missing_doi_returns_none_not_an_empty_string(self) -> None:
+        self.assertIsNone(_common.normalize_doi("no identifier here"))
+        self.assertIsNone(_common.normalize_doi(None))
+
+    def test_arxiv_ids_new_and_old(self) -> None:
+        self.assertEqual(_common.extract_arxiv_id("arXiv:1706.03762"), "1706.03762")
+        self.assertEqual(
+            _common.extract_arxiv_id("arXiv:2401.12345v2"), "2401.12345"
+        )
+        self.assertEqual(
+            _common.extract_arxiv_id("arXiv:cs/0112017"), "cs/0112017"
+        )
+        self.assertIsNone(_common.extract_arxiv_id("not an arxiv id"))
+
+    def test_pmid_extraction(self) -> None:
+        self.assertEqual(_common.extract_pmid("PMID: 35688944"), "35688944")
+        self.assertIsNone(_common.extract_pmid("no pmid"))
+
+
+class TitleMatchingTests(unittest.TestCase):
+    def test_identical_and_case_punct_variants_score_one(self) -> None:
+        base = "Attention Is All You Need"
+        self.assertEqual(_common.title_similarity(base, base), 1.0)
+        self.assertEqual(
+            _common.title_similarity(base, "attention  is all you  need!"), 1.0
+        )
+
+    def test_latex_and_math_are_folded_before_comparison(self) -> None:
+        self.assertEqual(
+            _common.title_similarity(
+                "The \\emph{Invariant} Measure of $L^2$ Flows",
+                "The Invariant Measure of Flows",
+            ),
+            1.0,
+        )
+
+    def test_subtitles_do_not_split_a_match(self) -> None:
+        score = _common.title_similarity(
+            "Highly accurate protein structure prediction with AlphaFold",
+            "Highly accurate protein structure prediction",
+        )
+        self.assertGreaterEqual(score, _common.MATCH_THRESHOLD
+                                if hasattr(_common, "MATCH_THRESHOLD") else 0.85)
+
+    def test_unrelated_titles_score_low(self) -> None:
+        score = _common.title_similarity(
+            "Attention Is All You Need", "Quantum leverage in protein folding"
+        )
+        self.assertLess(score, 0.5)
+
+    def test_empty_titles_never_match(self) -> None:
+        self.assertEqual(_common.title_similarity("", "anything"), 0.0)
+        self.assertEqual(_common.title_similarity(None, None), 0.0)
+
+
+class MetadataComparisonTests(unittest.TestCase):
+    def test_agreeing_records_produce_no_reasons(self) -> None:
+        reasons = _common.compare_metadata(
+            {"title": "Attention Is All You Need", "year": "2017",
+             "authors": "Vaswani, Ashish"},
+            {"title": "Attention is all you need", "year": 2017,
+             "author": [{"family": "Vaswani", "given": "Ashish"}]},
+        )
+        self.assertEqual(reasons, [])
+
+    def test_wrong_year_is_reported(self) -> None:
+        reasons = _common.compare_metadata(
+            {"title": "Attention Is All You Need", "year": "2017"},
+            {"title": "Attention is all you need", "year": 2014,
+             "author": [{"family": "Vaswani"}]},
+        )
+        self.assertTrue(any("year" in reason for reason in reasons))
+
+    def test_wrong_first_author_is_reported(self) -> None:
+        reasons = _common.compare_metadata(
+            {"title": "Attention Is All You Need", "year": "2017",
+             "authors": "Zhang, L."},
+            {"title": "Attention is all you need", "year": 2017,
+             "author": [{"family": "Vaswani"}]},
+        )
+        self.assertTrue(any("author" in reason for reason in reasons))
+
+    def test_year_tolerance_accepts_off_by_one(self) -> None:
+        reasons = _common.compare_metadata(
+            {"title": "A Paper", "year": "2020", "authors": "Roe, J."},
+            {"title": "A paper", "year": 2021, "author": [{"family": "Roe"}]},
+        )
+        self.assertEqual(reasons, [])
+
+
+class BibTeXParsingTests(unittest.TestCase):
+    def test_fixture_entries_parse_with_identifiers(self) -> None:
+        text = (FIXTURES / "sample.bib").read_text(encoding="utf-8")
+        entries = parse_references.parse_bibtex(text)
+        keys = [entry["key"] for entry in entries]
+        self.assertEqual(keys, ["jumper2021", "vaswani2017", "singleline"])
+        jumper = entries[0]
+        self.assertEqual(jumper["doi"], "10.1038/s41586-021-03819-2")
+        self.assertEqual(jumper["year"], "2021")
+        self.assertIn("AlphaFold", jumper["title"])
+        vaswani = entries[1]
+        self.assertEqual(vaswani["arxiv_id"], "1706.03762")
+
+    def test_comments_and_preamble_are_skipped(self) -> None:
+        text = "@preamble{\"stuff\"}\n@comment{note}\n@article{a, title = {T}}"
+        entries = parse_references.parse_bibtex(text)
+        self.assertEqual([entry["key"] for entry in entries], ["a"])
+
+    def test_single_line_entry_is_captured(self) -> None:
+        text = "@misc{s, title = {T}, year = {2020}, doi = {10.1000/xyz123}}"
+        entries = parse_references.parse_bibtex(text)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["doi"], "10.1000/xyz123")
+
+
+class MarkdownParsingTests(unittest.TestCase):
+    def test_fixture_references_are_extracted_in_order(self) -> None:
+        text = (FIXTURES / "sample_manuscript.md").read_text(encoding="utf-8")
+        entries = parse_references.parse_markdown(text)
+        self.assertEqual(len(entries), 4)
+        self.assertEqual([entry["key"] for entry in entries], ["1", "2", "3", "4"])
+
+    def test_identifiers_survive_extraction(self) -> None:
+        text = (FIXTURES / "sample_manuscript.md").read_text(encoding="utf-8")
+        entries = parse_references.parse_markdown(text)
+        held = entries[0]
+        self.assertEqual(held["doi"], "10.1080/24733938.2025.1234567")
+        self.assertEqual(held["year"], "2025")
+        vaswani = entries[2]
+        self.assertEqual(vaswani["arxiv_id"], "1706.03762")
+
+    def test_titles_are_extracted_from_numbered_references(self) -> None:
+        text = (FIXTURES / "sample_manuscript.md").read_text(encoding="utf-8")
+        entries = parse_references.parse_markdown(text)
+        self.assertIn("Attention Is All You Need", entries[2]["title"])
+        self.assertIn("VARS", entries[0]["title"])
+
+    def test_text_before_the_references_heading_is_not_parsed(self) -> None:
+        text = (FIXTURES / "sample_manuscript.md").read_text(encoding="utf-8")
+        entries = parse_references.parse_markdown(text)
+        self.assertFalse(
+            any("Vision-Language" in (entry["title"] or "") for entry in entries)
+        )
+
+
+class LaTeXParsingTests(unittest.TestCase):
+    def test_bibitem_entries_with_labels_parse(self) -> None:
+        text = (
+            "\\begin{thebibliography}{9}\n"
+            "% a comment\n"
+            "\\bibitem{vaswani2017} Vaswani, A. (2017). Attention Is All You Need. NeurIPS.\n"
+            "\\bibitem[Jumper2021]{jumper21} Jumper, J. (2021). Protein structure. Nature.\n"
+            "\\end{thebibliography}\n"
+        )
+        entries = parse_references.parse_latex(text)
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0]["key"], "vaswani2017")
+        self.assertEqual(entries[1]["key"], "jumper21")
+        self.assertIn("Attention Is All You Need", entries[0]["title"])
+
+    def test_latex_markup_is_rendered_down(self) -> None:
+        text = "\\bibitem{e} Einstein, A. (1905). On the \\emph{Electrodynamics} of Moving Bodies. Ann. Phys.\n"
+        entries = parse_references.parse_latex(text)
+        self.assertEqual(entries[0]["title"], "On the Electrodynamics of Moving Bodies")
+
+
+class InTextCitationTests(unittest.TestCase):
+    def test_checkable_sentences_with_markers_are_extracted(self) -> None:
+        text = (
+            "The MVFoul winner reached 44.76 combined balanced accuracy [2]. "
+            "Our method uses a vision-language model. Referees agree weakly "
+            "\"severity is a distribution\" (Held et al., 2025)."
+        )
+        found = parse_references.extract_in_text_citations(text)
+        self.assertEqual(len(found), 2)
+        self.assertEqual(found[0]["markers"], ["[2]"])
+        self.assertIn("44.76", found[0]["sentence"])
+        self.assertEqual(found[1]["quote"], "severity is a distribution")
+
+    def test_plain_sentences_without_markers_are_ignored(self) -> None:
+        text = "The model has 94.5 percent accuracy. Nothing here is cited."
+        self.assertEqual(parse_references.extract_in_text_citations(text), [])
+
+
+class VerdictLogicTests(unittest.TestCase):
+    def test_entry_without_identifier_or_title_is_skipped(self) -> None:
+        result = verify_references.resolve_reference({"key": "9", "type": "text"})
+        self.assertEqual(result["verdict"], _common.SKIPPED)
+
+    def test_taxonomy_constants_are_shared(self) -> None:
+        # The report renderer and the verifier must agree on verdict strings.
+        for verdict in (
+            _common.VERIFIED,
+            _common.METADATA_MISMATCH,
+            _common.RETRACTED,
+            _common.NOT_FOUND,
+            _common.UNRESOLVED,
+            _common.SKIPPED,
+        ):
+            self.assertIn(verdict, _common.VERDICT_ORDER)
+            self.assertIn(verdict, generate_report._VERDICT_GLYPH)
+
+
+class ReportRenderingTests(unittest.TestCase):
+    RESULTS = [
+        {"key": "1", "title": "A Real Paper", "year": "2021",
+         "verdict": "verified",
+         "resolved": {"title": "A Real Paper", "year": 2021, "container": "Nature"}},
+        {"key": "2", "title": "Quantum leverage in protein folding",
+         "verdict": "not-found", "doi": "10.5555/fake",
+         "detail": "no record found in any queried provider",
+         "resolved": {}},
+        {"key": "3", "title": "A Retracted Study", "verdict": "retracted",
+         "resolved": {"title": "A Retracted Study", "year": 2019},
+         "retraction_detail": "update-to: retraction (10.5555/retract)"},
+        {"key": "4", "title": "A Misdated Paper", "verdict": "metadata-mismatch",
+         "resolved": {"title": "A Misdated Paper", "year": 2013},
+         "mismatch_reasons": ["year mismatch: stated 2020 vs resolved 2013"]},
+    ]
+
+    def test_report_contains_coverage_and_flagged_groups(self) -> None:
+        report = generate_report.render_report(self.RESULTS)
+        self.assertIn("# Citation audit", report)
+        self.assertIn("**coverage:** 25%", report)
+        self.assertIn("## retracted (1)", report)
+        self.assertIn("## not-found (1)", report)
+        self.assertIn("## metadata-mismatch (1)", report)
+        self.assertIn("10.5555/retract", report)
+        self.assertIn("year mismatch: stated 2020 vs resolved 2013", report)
+
+    def test_flagged_sections_come_before_the_full_table(self) -> None:
+        report = generate_report.render_report(self.RESULTS)
+        self.assertLess(report.index("## retracted"), report.index("## All references"))
+
+    def test_clean_reports_say_so(self) -> None:
+        report = generate_report.render_report(
+            [{"key": "1", "title": "Fine", "verdict": "verified",
+              "resolved": {"title": "Fine", "year": 2020}}]
+        )
+        self.assertNotIn("## retracted", report)
+        self.assertIn("## All references", report)
+
+    def test_empty_input_renders_a_usable_report(self) -> None:
+        report = generate_report.render_report([])
+        self.assertIn("No references", report)
+
+    def test_summarize_counts_by_verdict(self) -> None:
+        counts = generate_report.summarize(self.RESULTS)
+        self.assertEqual(counts, {"verified": 1, "not-found": 1,
+                                  "retracted": 1, "metadata-mismatch": 1})
+
+
+class RetractionSweepTests(unittest.TestCase):
+    def test_dois_are_collected_from_json_and_text(self) -> None:
+        payload = FIXTURES.parent / "retraction_input.json"
+        payload.write_text(json.dumps({"references": [
+            {"doi": "10.1038/s41586-021-03819-2"},
+            {"raw": "also 10.1000/abc123 here"},
+        ]}), encoding="utf-8")
+        self.addCleanup(payload.unlink)
+        bib = FIXTURES / "sample.bib"
+        dois = check_retractions.collect_dois(
+            [str(payload), str(bib)], ["10.1000/dup"]
+        )
+        self.assertIn("10.1038/s41586-021-03819-2", dois)
+        self.assertIn("10.1000/abc123", dois)
+        self.assertIn("10.1038/s41586-021-03819-2", dois)
+        self.assertIn("10.1000/xyz123", dois)  # from the .bib
+        self.assertIn("10.1000/dup", dois)
+        self.assertEqual(len(dois), len(set(dois)), "duplicates must be dropped")
+
+    def test_a_doi_with_no_doi_shaped_text_yields_nothing(self) -> None:
+        plain = FIXTURES.parent / "plain.txt"
+        plain.write_text("no identifiers at all", encoding="utf-8")
+        self.addCleanup(plain.unlink)
+        self.assertEqual(check_retractions.collect_dois([str(plain)], []), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #251 (implements the `verify-citations` skill that PR proposes — with the scripts and tests this repo's contract expects).

## What this adds

`citation-management` finds, formats, and generates references; this skill **audits an existing manuscript's reference list** — the pre-submission check that LLM-assisted writing now needs (hallucinated references, garbled metadata, retracted sources).

**Pipeline:** parse → resolve → compare → report

1. `parse_references.py` — extracts a structured reference list from markdown (numbered/bulleted sections), LaTeX (`\bibitem`), or BibTeX (brace-depth parser), recovering DOI/arXiv-ID/PMID/title/authors/year per entry. `--in-text` also extracts checkable citation sentences.
2. `verify_references.py` — resolves each entry: DOI → Crossref, arXiv ID → Atom API, PMID → E-utilities, title-only → Crossref bibliographic search (title similarity ≥ 0.85). Compares stated vs canonical metadata (year ±1, first-author surname, title).
3. `check_retractions.py` — standalone retraction sweep: Crossref `update-to`/`updated-by` (official notices), OpenAlex `is_retracted` fallback.
4. `generate_report.py` — offline markdown audit report, flagged entries worst-first, with stated-vs-resolved evidence per citation.

**Verdict taxonomy** (shared, documented in `references/verdicts.md`): `verified` / `metadata-mismatch` / `retracted` / `not-found` / `unresolved` / `skipped`.

## Live smoke results

On a fixture manuscript with one real citation, one with a wrong year, one hallucinated, and one DOI-invalid entry:

```
verified 4 references: {'metadata-mismatch': 2, 'not-found': 1, 'verified': 1}
```

And on the (retracted) Wakefield paper:

```json
{"doi": "10.1016/s0140-6736(97)11096-0", "verdict": "retracted",
 "detail": "Crossref updated-by marks this work as retraction",
 "notice_doi": "10.1016/s0140-6736(10)60175-4"}
```

## Contract compliance

- 36 offline tests (`tests/verify-citations/`): parsing fixtures, identifier normalisation, title similarity (with subtitle containment), metadata comparison, report rendering, plus the CLI `--help` contract
- `tests/run_all.py verify-citations` passes; repo-wide `tests/_meta` passes (10 tests, 1224 subtests)
- `[skills.verify-citations]` added to `tests/skill-requirements.toml`
- SKILL.md frontmatter follows the six-field spec (block-mapping `metadata`, quoted version); all providers are keyless, with `CROSSREF_EMAIL`/`OPENALEX_EMAIL` polite-pool support

## Relationship to #251

@Sketchjar's PR wraps a single proprietary API (stipple.sh), ships no scripts or tests, and its frontmatter carries a top-level `tags:` field outside the spec's closed set. This implementation covers the same use case with open keyless providers, self-contained scripts, and the repo's test conventions. Happy to defer to theirs if maintainers prefer that direction — flagging the overlap explicitly here.