### PR TITLE
Add companion identifier APIs to ontology-term-resolution

### DIFF
--- a/skills/ontology-term-resolution/SKILL.md
+++ b/skills/ontology-term-resolution/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ontology-term-resolution
-description: Resolve free-text scientific labels to ontology term IDs and validate existing CURIEs against the EBI Ontology Lookup Service (OLS4). Use whenever an ontology identifier must be produced or checked - annotating tissue, cell type, disease, phenotype, assay, chemical, organism, sex, or developmental stage fields; preparing metadata for GEO, ENA, BioSamples, CELLxGENE, HCA, or ISA-Tab submission; auditing a metadata table of term IDs; checking whether a term is obsolete and what replaced it; or mapping between ontologies. Triggers include "ontology term", "ontology ID", "CURIE", "controlled vocabulary", "UBERON", "CL:", "MONDO", "HPO", "EFO", "ChEBI", "NCBITaxon", "GO term", "PATO", "annotate this tissue/cell type/disease", and any request to emit or verify an identifier shaped like PREFIX:0001234.
+description: Resolve free-text scientific labels to ontology term IDs and validate existing CURIEs against the EBI Ontology Lookup Service (OLS4). Also look up prefixes in Bioregistry, resolve compact identifiers via Identifiers.org, map lab shorthand with ZOOMA, and build Ontobee term pages. Use whenever an ontology identifier must be produced or checked - annotating tissue, cell type, disease, phenotype, assay, chemical, organism, sex, or developmental stage fields; preparing metadata for GEO, ENA, BioSamples, CELLxGENE, HCA, or ISA-Tab submission; auditing a metadata table of term IDs; checking whether a term is obsolete and what replaced it; or deciding HPO vs HP. Triggers include "ontology term", "ontology ID", "CURIE", "controlled vocabulary", "UBERON", "CL:", "MONDO", "HPO", "EFO", "ChEBI", "NCBITaxon", "GO term", "PATO", "Zooma", "Bioregistry", "Identifiers.org", "Ontobee", "annotate this tissue/cell type/disease", and any request to emit or verify an identifier shaped like PREFIX:0001234.
 license: MIT
-compatibility: Requires Python 3.11+. Scripts use only the standard library - no third-party packages. Needs network access to https://www.ebi.ac.uk/ols4 (public, no API key).
+compatibility: Requires Python 3.11+. Scripts use only the standard library - no third-party packages. Needs network access to https://www.ebi.ac.uk/ols4, https://bioregistry.io, https://resolver.api.identifiers.org, and https://www.ebi.ac.uk/spot/zooma (all public, no API key).
 allowed-tools: Read Write Edit Bash
 metadata:
   version: "1.1"
@@ -27,16 +27,21 @@ substitution — the ID is well-formed, the ontology is right, and the metadata 
 Reviewers cannot spot it either, which is why these errors persist into published datasets.
 
 Every ID this skill emits comes from a live OLS lookup. Every ID it is handed gets verified.
+Bioregistry, Identifiers.org, ZOOMA, and Ontobee answer prefix, landing-page, and shorthand
+questions — they do not replace that OLS check.
 
-## Two directions
+## Which service
 
-| Direction | Script | Question answered |
+| Question | Script | Authority |
 | --- | --- | --- |
-| text → ID | `scripts/resolve_terms.py` | What is the term for "left ventricle"? |
-| ID → verdict | `scripts/validate_terms.py` | Is `EFO:0001067` real, current, and labelled what this file claims? |
+| What is the term for "left ventricle"? | `scripts/resolve_terms.py` | OLS |
+| OLS missed lab shorthand (`PBMC`, `WT`) | `scripts/map_terms.py`, then `validate_terms.py` | ZOOMA proposes; OLS decides |
+| Is `EFO:0001067` real, current, correctly labelled? | `scripts/validate_terms.py` | OLS |
+| Is `HPO` a real prefix? Does `HP:notanid` match the pattern? | `scripts/lookup_prefix.py` | Bioregistry |
+| Which landing page should this CURIE open? | `scripts/lookup_prefix.py` | Identifiers.org + Ontobee URLs |
 
-Both take single values or files, emit TSV or JSON, and need no packages beyond the standard
-library.
+All four scripts take single values or files, emit TSV or JSON, and need no packages beyond the
+standard library. Full traps for the non-OLS services are in `references/companion-apis.md`.
 
 ## Resolve text to terms
 
@@ -110,6 +115,35 @@ python3 validate_terms.py --input tissue_ids.tsv \
 
 `--strict` promotes warnings to failures.
 
+## Check a prefix or compact identifier
+
+```bash
+python3 lookup_prefix.py HP HPO HP:0001250 HPO:0001250
+```
+
+```
+query        status          preferred_prefix  canonical_curie  pattern    detail
+HP           ok              HP                                 ^\d{7}$
+HPO          synonym_prefix  HP                                 ^\d{7}$    'HPO' is a synonym of preferred prefix HP
+HP:0001250   ok              HP                HP:0001250       ^\d{7}$
+HPO:0001250  synonym_prefix  HP                HP:0001250       ^\d{7}$    'HPO' is a synonym of preferred prefix HP
+```
+
+Bioregistry accepts synonym prefixes. Identifiers.org does not — `HPO:0001250` is HTTP 400.
+Rewrite to the preferred prefix before handing a CURIE to any other resolver. This script does
+**not** say the term exists; that is still `validate_terms.py`.
+
+## Map lab shorthand (ZOOMA)
+
+```bash
+# after resolve_terms.py returned unresolved / partial
+python3 map_terms.py PBMC --ontology cl --exact-only
+```
+
+`--ontology` is required. Unfiltered ZOOMA annotate returns FOODON, XAO, and BTO alongside UBERON
+for `liver`, all at HIGH confidence. HIGH/GOOD hits are candidates only — run `validate_terms.py`
+on every CURIE before writing it down.
+
 ## API behaviour that will mislead you
 
 These are verified against the live service and are the reason this skill ships scripts rather
@@ -125,6 +159,10 @@ than a recipe. Full detail in `references/ols4-api.md`.
 | IRIs are not all OBO PURLs | EFO and Orphanet use their own namespaces — resolve IRIs, do not template them |
 | OxO is retired | Returns HTML with HTTP 200; use term cross-references or SSSOM instead |
 | A branch check does not exclude cell types from anatomy | CARO puts `cell` under `anatomical structure`; constrain the prefix too |
+| ZOOMA without an ontology filter | `liver` returns 100+ HIGH hits across FOODON, XAO, BTO, UBERON |
+| Identifiers.org synonym prefixes | `HPO:0001250` is HTTP 400; Bioregistry accepted the same CURIE |
+| Identifiers.org encoded colon | `HP%3A0001250` is HTTP 400; the path must keep `:` |
+| Ontobee search | HTML page only — no JSON API; do not scrape it |
 
 ## Choosing the ontology
 
@@ -140,7 +178,9 @@ reviewed. State unresolved terms explicitly rather than filling them with the ne
 
 ## References
 
-- `references/ols4-api.md` — endpoints, parameters, response fields, and every verified trap.
+- `references/ols4-api.md` — endpoints, parameters, response fields, and every verified OLS trap.
+- `references/companion-apis.md` — Bioregistry, Identifiers.org, ZOOMA, and Ontobee: when to use
+  each, and the traps that make an unfiltered or synonym-prefix call look successful.
 - `references/ontology-registry.md` — prefix/ontology-id table, branch roots, which ontology owns
   which concept.
 - `references/curation-rules.md` — candidate-selection procedure, normalisations to retry,

--- a/skills/ontology-term-resolution/SKILL.md
+++ b/skills/ontology-term-resolution/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires Python 3.11+. Scripts use only the standard library - no third-party packages. Needs network access to https://www.ebi.ac.uk/ols4, https://bioregistry.io, https://resolver.api.identifiers.org, and https://www.ebi.ac.uk/spot/zooma (all public, no API key).
 allowed-tools: Read Write Edit Bash
 metadata:
-  version: "1.1"
+  version: "1.2"
   skill-author: K-Dense Inc.
 ---
 
@@ -130,7 +130,10 @@ HPO:0001250  synonym_prefix  HP                HP:0001250       ^\d{7}$    'HPO'
 ```
 
 Bioregistry accepts synonym prefixes. Identifiers.org does not — `HPO:0001250` is HTTP 400.
-Rewrite to the preferred prefix before handing a CURIE to any other resolver. This script does
+Rewrite to the preferred prefix before handing a CURIE to OLS. Landing-page columns come from
+Bioregistry mappings (`providers.miriam`, `mappings.ontobee`), not from templating that
+preferred prefix: `ORPHA:558` is a 400, `orphanet:558` is a 200, and OBA has no Identifiers.org
+namespace at all. Empty cells mean the service does not host the prefix. This script does
 **not** say the term exists; that is still `validate_terms.py`.
 
 ## Map lab shorthand (ZOOMA)
@@ -162,6 +165,7 @@ than a recipe. Full detail in `references/ols4-api.md`.
 | ZOOMA without an ontology filter | `liver` returns 100+ HIGH hits across FOODON, XAO, BTO, UBERON |
 | Identifiers.org synonym prefixes | `HPO:0001250` is HTTP 400; Bioregistry accepted the same CURIE |
 | Identifiers.org encoded colon | `HP%3A0001250` is HTTP 400; the path must keep `:` |
+| Bioregistry `preferred_prefix` is not the Identifiers.org namespace | `ORPHA:558` is 400; `orphanet:558` is 200. `hp:0001250` and `chebi:15377` are 400 because those namespaces embed the prefix in the LUI. Use `providers.miriam` from `/api/reference/{CURIE}`; omit the URL when that mapping is missing (OBA, XAO, ECTO) |
 | Ontobee search | HTML page only — no JSON API; do not scrape it |
 
 ## Choosing the ontology

--- a/skills/ontology-term-resolution/references/companion-apis.md
+++ b/skills/ontology-term-resolution/references/companion-apis.md
@@ -1,0 +1,158 @@
+# Companion identifier services
+
+OLS is the authority for "does this term exist, and is it current?". The four
+services below answer different questions. Every behaviour here was checked
+against the live APIs in September 2026.
+
+| Service | Use it for | Do not use it for |
+| --- | --- | --- |
+| Bioregistry | Is this prefix real? Does the local id match the recorded pattern? What is the preferred prefix? | Whether the term exists or is obsolete |
+| Identifiers.org | Landing-page URLs for a *preferred-prefix* CURIE | Synonym prefixes (`HPO:…`); existence checks |
+| ZOOMA | Mapping lab shorthand OLS cannot lexical-match | Unfiltered annotate; writing an ID without OLS validation |
+| Ontobee | The OBO Foundry HTML/RDF page for a term IRI | Search, validation, or routine resolution — there is no JSON search API |
+
+## Bioregistry
+
+Base URL: `https://bioregistry.io/api`. No API key.
+
+| Endpoint | Question |
+| --- | --- |
+| `GET /registry/{prefix}` | What is this prefix? Accepts synonyms. |
+| `GET /reference/{CURIE}` | Is the local id well-formed, and which providers resolve it? |
+| `GET /search?q=` | Prefix search. Returns `[[canonical, synonym], …]`. |
+
+Useful record fields: `prefix` (canonical, usually lowercase), `preferred_prefix`
+(`HP`, `CHEBI`), `pattern` (regex for the **local** id only), `example`,
+`uri_format` (`$1` is the local id), `synonyms`, `mappings.ols`,
+`mappings.ontobee`, `mappings.miriam`.
+
+`lookup_prefix.py` wraps the first two endpoints.
+
+### Trap — synonym prefixes resolve here and fail elsewhere
+
+```
+GET /registry/HPO          -> 200, prefix=hp, preferred_prefix=HP, synonyms=["hpo"]
+GET /reference/HPO:0001250 -> 200, same providers as HP:0001250
+GET https://resolver.api.identifiers.org/HPO:0001250
+                           -> 400, "NOT A NAMESPACE"
+```
+
+If a metadata file writes `HPO:0001250`, Bioregistry will look fine and
+Identifiers.org will reject the compact identifier. Rewrite to the preferred
+prefix (`HP:0001250`) before handing the CURIE to any other resolver.
+
+### Trap — 404 is two different failures
+
+`/reference/{CURIE}` returns HTTP 404 with a JSON `detail` for both:
+
+- unknown prefix: `"Prefix not found: …"`
+- known prefix, bad local id: `"invalid identifier: hp:notanid for pattern ^\\d{7}$"`
+
+Read `detail`. Treating both as "no such prefix" hides a well-formed-prefix,
+malformed-local-id error. Client-side `re.fullmatch(pattern, local)` is the
+same check and does not need a network call once you have the record.
+
+### Trap — `pattern` is the local id, not the CURIE
+
+`HP` has `pattern: ^\d{7}$`. `0001250` matches; `HP:0001250` does not. Never
+run the regex against the whole CURIE.
+
+## Identifiers.org
+
+Resolver: `https://resolver.api.identifiers.org/{CURIE}`. Registry docs at
+https://docs.identifiers.org/. No API key.
+
+A successful body is `{apiVersion, errorMessage: null, payload: {resolvedResources: […]}}`.
+Each resource has `compactIdentifierResolvedUrl`, `providerCode`, `official`,
+and `recommendation.recommendationIndex`.
+
+### Trap — preferred prefix only
+
+Identifiers.org namespaces are the MIRIAM / preferred form. `HP:0001250`
+resolves; `HPO:0001250` is HTTP 400. Always run Bioregistry first and pass
+`{preferred_prefix}:{local}`.
+
+### Trap — do not encode the colon
+
+`https://resolver.api.identifiers.org/HP:0001250` works.
+`https://resolver.api.identifiers.org/HP%3A0001250` is HTTP 400
+("NOT A NAMESPACE"). Leave `:` unencoded in the path.
+
+A 400 body still parses as JSON — `errorMessage` is set and
+`resolvedResources` is null. That is a rejected compact identifier, not a
+transport failure.
+
+## ZOOMA
+
+Annotate: `https://www.ebi.ac.uk/spot/zooma/v2/api/services/annotate`.
+No API key. Slow — budget tens of seconds; the client uses a 60 s timeout.
+
+| Parameter | Effect |
+| --- | --- |
+| `propertyValue` | The free-text string. |
+| `propertyType` | Optional slot (`organism part`, `cell type`, `disease`). Helps when the same word is used in several roles. |
+| `filter` | **Required.** `required:[none],ontologies:[uberon]` or comma-separated OLS ids. |
+
+Hits carry `confidence` (`HIGH` / `GOOD` / `MEDIUM` / `LOW`), `semanticTags`
+(IRIs, not CURIEs), and `provenance.evidence` (`ZOOMA_INFERRED_FROM_CURATED`
+or `OLS_TEXT_TAGGER`).
+
+`map_terms.py` refuses to run without `--ontology`, converts IRIs with
+`iri_to_curie`, and labels HIGH/GOOD as `zooma_safe` and the rest as
+`zooma_weak`.
+
+### Trap — unfiltered annotate is unusable
+
+```
+propertyValue=liver
+  -> 118 hits, HIGH: FOODON:03309772, XAO:0000133, UBERON:0002107, BTO:0000759, …
+propertyValue=liver&propertyType=organism+part&filter=required:[none],ontologies:[uberon]
+  -> 10 hits, first tag UBERON:0002107
+```
+
+An earlier check of the unfiltered call also returned
+`https://w3id.org/gold.vocab/Liver`. Never call annotate without an ontology
+filter.
+
+### Trap — HIGH is not "write this ID"
+
+`PBMC` filtered to `cl` returns `CL:2000001` at HIGH and several other cell
+types at MEDIUM. Still run `validate_terms.py` on the CURIE: ZOOMA does not
+report obsolescence, defining ontology, or branch membership, and its IRIs
+still need the EFO / Orphanet / OBO split that `iri_to_curie` already knows.
+
+## Ontobee
+
+Ontobee is the default linked-data server for most OBO Foundry ontologies.
+It serves an HTML page and RDF for a term IRI. It is not a resolver and it
+has no JSON search API.
+
+Term page:
+
+```
+https://ontobee.org/ontology/{PREFIX}?iri={url-encoded IRI}
+```
+
+`lookup_prefix.py` builds this from Bioregistry `preferred_prefix` +
+`uri_format`. Example: `HP:0001250` →
+`https://ontobee.org/ontology/HP?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FHP_0001250`.
+
+HTML keyword search (`/search?ontology=UBERON&keywords=liver`) is a browser
+page, not an API — do not scrape it. For text → ID use OLS (or ZOOMA for
+shorthand). For ID → verdict use OLS.
+
+SPARQL is available at the Hegroup endpoint documented on
+https://ontobee.org/tutorial/sparql, for axiom queries OLS does not expose.
+The graph URI pattern (`http://purl.obolibrary.org/obo/merged/FOO`) is not
+reliable; do not put SPARQL in a routine resolve/validate path.
+
+## Which call to make
+
+1. Prefix looks wrong, or you need a landing page → `lookup_prefix.py`.
+2. Free text, expected ontology known → `resolve_terms.py` (OLS).
+3. OLS returned unresolved / partial on lab shorthand → `map_terms.py`, then
+   `validate_terms.py` on every CURIE you might keep.
+4. You already have a CURIE → `validate_terms.py` (OLS). Optionally
+   `lookup_prefix.py` first if the prefix itself might be a synonym.
+5. You want the OBO Foundry page for a known IRI → the Ontobee URL from
+   `lookup_prefix.py`, not a new search.

--- a/skills/ontology-term-resolution/references/companion-apis.md
+++ b/skills/ontology-term-resolution/references/companion-apis.md
@@ -7,7 +7,7 @@ against the live APIs in September 2026.
 | Service | Use it for | Do not use it for |
 | --- | --- | --- |
 | Bioregistry | Is this prefix real? Does the local id match the recorded pattern? What is the preferred prefix? | Whether the term exists or is obsolete |
-| Identifiers.org | Landing-page URLs for a *preferred-prefix* CURIE | Synonym prefixes (`HPO:…`); existence checks |
+| Identifiers.org | Landing-page URLs from Bioregistry `providers.miriam` | Synonym prefixes (`HPO:…`); templating `preferred_prefix`; existence checks |
 | ZOOMA | Mapping lab shorthand OLS cannot lexical-match | Unfiltered annotate; writing an ID without OLS validation |
 | Ontobee | The OBO Foundry HTML/RDF page for a term IRI | Search, validation, or routine resolution — there is no JSON search API |
 
@@ -66,11 +66,25 @@ A successful body is `{apiVersion, errorMessage: null, payload: {resolvedResourc
 Each resource has `compactIdentifierResolvedUrl`, `providerCode`, `official`,
 and `recommendation.recommendationIndex`.
 
-### Trap — preferred prefix only
+### Trap — preferred prefix is not the Identifiers.org namespace
 
-Identifiers.org namespaces are the MIRIAM / preferred form. `HP:0001250`
-resolves; `HPO:0001250` is HTTP 400. Always run Bioregistry first and pass
-`{preferred_prefix}:{local}`.
+Bioregistry `preferred_prefix` is the form OLS wants. It is not the MIRIAM
+compact-identifier namespace, and not every prefix has one:
+
+```
+GET /reference/orphanet:558  -> providers.miriam = https://identifiers.org/orphanet:558
+GET resolver/ORPHA:558       -> 400 NOT A NAMESPACE   (preferred_prefix is ORPHA)
+GET resolver/orphanet:558    -> 200
+GET /reference/OBA:0000001   -> no providers.miriam   (OBA, XAO, ECTO have none)
+GET resolver/hp:0001250      -> 400                   (namespace embeds HP: in the LUI)
+GET resolver/CHEBI:15377     -> 200
+GET resolver/chebi:15377     -> 400
+```
+
+Always take the landing page from `/api/reference/{CURIE}` `providers.miriam`.
+Leave the column empty when that mapping is missing. Do not template
+`https://identifiers.org/{preferred_prefix}:{local}` — that is how
+`ORPHA:558` and `OBA:0000001` become dead links next to a rejection note.
 
 ### Trap — do not encode the colon
 
@@ -133,9 +147,12 @@ Term page:
 https://ontobee.org/ontology/{PREFIX}?iri={url-encoded IRI}
 ```
 
-`lookup_prefix.py` builds this from Bioregistry `preferred_prefix` +
+`lookup_prefix.py` builds this only when the registry record has
+`mappings.ontobee`, using that value (not `preferred_prefix`) plus
 `uri_format`. Example: `HP:0001250` →
 `https://ontobee.org/ontology/HP?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FHP_0001250`.
+Orphanet has no `mappings.ontobee` — the templated `ORPHA` / `ORDO` page is
+HTTP 500 — so that cell stays empty.
 
 HTML keyword search (`/search?ontology=UBERON&keywords=liver`) is a browser
 page, not an API — do not scrape it. For text → ID use OLS (or ZOOMA for

--- a/skills/ontology-term-resolution/references/curation-rules.md
+++ b/skills/ontology-term-resolution/references/curation-rules.md
@@ -39,9 +39,10 @@ Do **not** normalise away hyphens, Greek letters, digits, or capitalised gene sy
 and `alpha-beta T cell` mean what they say, and `normalize_label()` deliberately folds only case and
 whitespace.
 
-When plain search keeps failing on lab shorthand, try ZOOMA with an ontology filter
-(`ols4-api.md`). It matches against how curators previously mapped that exact string, which is a
-different and often better signal than lexical search.
+When plain search keeps failing on lab shorthand, run `map_terms.py` with `--ontology` set
+(see `companion-apis.md`). ZOOMA matches against how curators previously mapped that exact
+string, which is a different and often better signal than lexical search. Every HIGH/GOOD
+CURIE still goes through `validate_terms.py` before it is written down.
 
 ## What "unresolved" should look like
 

--- a/skills/ontology-term-resolution/references/ols4-api.md
+++ b/skills/ontology-term-resolution/references/ols4-api.md
@@ -117,17 +117,10 @@ Do not template IRIs when you can resolve them. The OBO PURL pattern is not univ
 
 ## Related services
 
-**ZOOMA** (`https://www.ebi.ac.uk/spot/zooma/v2/api/services/annotate`) maps free text to terms
-using curated annotation history. Unfiltered it is unusable — `propertyValue=liver` returns
-`https://w3id.org/gold.vocab/Liver`. Always pass a filter:
-
-```
-?propertyValue=liver&propertyType=organism+part&filter=required:[none],ontologies:[uberon]
-```
-
-which returns `UBERON:0002107` and related terms with `confidence: HIGH|GOOD` and
-`evidence: ZOOMA_INFERRED_FROM_CURATED`. Worth trying when OLS search fails on lab shorthand,
-because it has seen how curators mapped that exact string before.
+**ZOOMA, Bioregistry, Identifiers.org, and Ontobee** are documented in
+`companion-apis.md`. Use `map_terms.py` (ontology filter required) when OLS
+search fails on lab shorthand, and `lookup_prefix.py` for prefix/CURIE shape
+and landing pages. None of them replace OLS for emitting or validating a term.
 
 **OxO** (`https://www.ebi.ac.uk/spot/oxo/api/...`) is **retired**. It returns an HTML upgrade
 notice with HTTP **200**, so a naive `curl | jq` fails confusingly rather than cleanly. For

--- a/skills/ontology-term-resolution/references/ontology-registry.md
+++ b/skills/ontology-term-resolution/references/ontology-registry.md
@@ -14,7 +14,7 @@ The OLS ontology id is almost always the lowercased CURIE prefix. Note the excep
 | `CLO` | `clo` | Cell lines |
 | `MONDO` | `mondo` | Diseases (the merged disease ontology; prefer over DOID/NCIT) |
 | `DOID` | `doid` | Human Disease Ontology (largely subsumed by MONDO) |
-| `HP` | `hp` | Human phenotypic abnormalities — **id is `hp`, not `hpo`** |
+| `HP` | `hp` | Human phenotypic abnormalities — **id is `hp`, not `hpo`**. `HPO` is a Bioregistry synonym; Identifiers.org rejects `HPO:…` |
 | `EFO` | `efo` | Experimental factors, assays, platforms, cell lines |
 | `CHEBI` | `chebi` | Chemical entities, drugs, metabolites |
 | `NCBITaxon` | `ncbitaxon` | Organisms |

--- a/skills/ontology-term-resolution/scripts/id_client.py
+++ b/skills/ontology-term-resolution/scripts/id_client.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Prefix and compact-identifier helpers for Bioregistry and Identifiers.org.
+
+OLS remains the authority for whether a *term* exists and is current. These
+services answer a different question: is this prefix real, is the local id
+well-formed, and which landing pages resolve it?
+
+Standard library only. Network access to https://bioregistry.io and
+https://resolver.api.identifiers.org is required for the request functions;
+helpers below the ``--- pure helpers ---`` mark are offline.
+
+Verified against the live APIs in September 2026 (see
+``references/companion-apis.md``):
+
+* ``/api/registry/{prefix}`` accepts synonyms (``HPO`` → ``hp``) and returns
+  the canonical record. A 404 body is ``{"detail": "Prefix not found: ..."}``.
+* ``/api/reference/{CURIE}`` validates the local id against ``pattern``. A
+  404 body of ``{"detail": "invalid identifier: ..."}`` means the prefix is
+  known and the local part is wrong — not that the prefix is unknown.
+* Identifiers.org rejects synonym prefixes (``HPO:0001250`` → HTTP 400).
+  Always resolve through the Bioregistry preferred prefix first.
+"""
+from __future__ import annotations
+
+import json
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+BIOREGISTRY_BASE = "https://bioregistry.io/api"
+IDENTIFIERS_RESOLVER = "https://resolver.api.identifiers.org"
+ONTOBEE_TERM = "https://ontobee.org/ontology/{prefix}?iri={iri}"
+USER_AGENT = "scientific-agent-skills-ontology-term-resolution/1.1"
+TIMEOUT = 30
+MAX_ATTEMPTS = 3
+RETRY_STATUS = {429, 500, 502, 503, 504}
+
+CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9_.]*):(.+)$")
+PREFIX_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.]*$")
+
+
+class IdError(RuntimeError):
+    """A request to Bioregistry or Identifiers.org failed unrecoverably."""
+
+
+class NotFoundError(IdError):
+    """The remote service answered 404 with a JSON ``detail`` body."""
+
+    def __init__(self, detail: str, url: str):
+        super().__init__(detail)
+        self.detail = detail
+        self.url = url
+
+
+def _request(url: str) -> dict:
+    """GET a JSON document, retrying transient failures."""
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, "Accept": "application/json"})
+    last: Exception | None = None
+    for attempt in range(MAX_ATTEMPTS):
+        try:
+            with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            if exc.code == 404:
+                detail = _detail_from_body(body) or f"HTTP 404 for {url}"
+                raise NotFoundError(detail, url) from exc
+            last = exc
+            if exc.code not in RETRY_STATUS:
+                raise IdError(f"HTTP {exc.code} for {url}: {body[:200]}") from exc
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            last = exc
+        if attempt < MAX_ATTEMPTS - 1:
+            time.sleep(1.5 * (attempt + 1))
+    raise IdError(f"request failed after {MAX_ATTEMPTS} attempts: {url} ({last})")
+
+
+def _detail_from_body(body: str) -> str:
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return body.strip()[:200]
+    if isinstance(payload, dict):
+        return str(payload.get("detail") or payload.get("errorMessage") or body[:200])
+    return body.strip()[:200]
+
+
+def get_resource(prefix: str) -> dict:
+    """Return the Bioregistry record for a prefix or synonym, or raise NotFoundError."""
+    encoded = urllib.parse.quote(prefix, safe="")
+    return _request(f"{BIOREGISTRY_BASE}/registry/{encoded}")
+
+
+def get_reference(curie: str) -> dict:
+    """Resolve a CURIE to provider URLs, validating the local id.
+
+    Raises ``NotFoundError`` when the prefix is unknown *or* the local id
+    fails the recorded pattern — inspect ``detail`` to tell them apart.
+    """
+    encoded = urllib.parse.quote(curie, safe="")
+    return _request(f"{BIOREGISTRY_BASE}/reference/{encoded}")
+
+
+def identifiers_resolver_url(curie: str) -> str:
+    """Build the Identifiers.org resolver URL.
+
+    The colon in ``PREFIX:local`` must stay a colon. Encoding it as ``%3A``
+    is HTTP 400: ``NOT A NAMESPACE`` for a CURIE the service otherwise accepts.
+    """
+    encoded = urllib.parse.quote(curie, safe=":")
+    return f"{IDENTIFIERS_RESOLVER}/{encoded}"
+
+
+def resolve_identifiers(curie: str) -> dict:
+    """Ask Identifiers.org for landing pages. Returns the JSON payload.
+
+    A rejected compact identifier comes back as HTTP 400 with
+    ``errorMessage`` set and ``payload.resolvedResources`` null — that is
+    returned as a dict, not raised, so the caller can report it.
+    """
+    url = identifiers_resolver_url(curie)
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, "Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            raise IdError(f"Identifiers.org HTTP {exc.code} for {curie}: {body[:200]}") from exc
+        if isinstance(payload, dict):
+            return payload
+        raise IdError(f"Identifiers.org HTTP {exc.code} for {curie}") from exc
+
+
+# --- pure helpers -----------------------------------------------------------
+
+
+def split_query(value: str) -> tuple[str, str | None]:
+    """Split ``PREFIX`` or ``PREFIX:local`` into ``(prefix, local_or_None)``."""
+    text = value.strip()
+    match = CURIE_RE.match(text)
+    if match:
+        return match.group(1), match.group(2)
+    return text, None
+
+
+def is_prefix(value: str) -> bool:
+    """True for a bare registry prefix, false for CURIEs and junk."""
+    return bool(PREFIX_RE.match(value.strip())) and ":" not in value.strip()
+
+
+def local_matches_pattern(local: str, pattern: str | None) -> bool | None:
+    """Check a local unique id against a Bioregistry regex.
+
+    Returns ``None`` when the registry has no pattern, so the caller can
+    distinguish "unchecked" from "failed".
+    """
+    if not pattern:
+        return None
+    return re.fullmatch(pattern, local) is not None
+
+
+def apply_uri_format(uri_format: str | None, local: str) -> str | None:
+    """Fill a Bioregistry ``uri_format`` template (``$1`` is the local id)."""
+    if not uri_format or "$1" not in uri_format:
+        return None
+    return uri_format.replace("$1", local)
+
+
+def ontobee_url(preferred_prefix: str | None, iri: str | None) -> str | None:
+    """Build the Ontobee HTML/RDF page for a term IRI.
+
+    Ontobee has no JSON search API. The page is the product: HTML for
+    humans, RDF when the same IRI is dereferenced as linked data.
+    """
+    if not preferred_prefix or not iri:
+        return None
+    return ONTOBEE_TERM.format(
+        prefix=preferred_prefix,
+        iri=urllib.parse.quote(iri, safe=""),
+    )
+
+
+def identifiers_landing_pages(payload: dict) -> list[dict[str, Any]]:
+    """Flatten Identifiers.org ``resolvedResources`` into compact rows."""
+    resources = (payload.get("payload") or {}).get("resolvedResources") or []
+    rows = []
+    for item in resources:
+        rec = item.get("recommendation") or {}
+        rows.append(
+            {
+                "provider": item.get("providerCode") or "official",
+                "url": item.get("compactIdentifierResolvedUrl") or "",
+                "official": bool(item.get("official")),
+                "score": rec.get("recommendationIndex"),
+            }
+        )
+    rows.sort(key=lambda row: (not row["official"], -(row["score"] or 0)))
+    return rows
+
+
+def classify_prefix_query(
+    query: str,
+    resource: dict | None,
+    *,
+    local: str | None,
+    reference_detail: str | None = None,
+) -> dict:
+    """Build the status record for one prefix or CURIE lookup.
+
+    Pure: callers supply the Bioregistry payload (or ``None`` on 404).
+    """
+    prefix, parsed_local = split_query(query)
+    local = local if local is not None else parsed_local
+    result = {
+        "query": query,
+        "status": "ok",
+        "preferred_prefix": "",
+        "canonical_curie": "",
+        "pattern": "",
+        "example": "",
+        "name": "",
+        "default_iri": "",
+        "identifiers_org": "",
+        "ontobee": "",
+        "ols_id": "",
+        "detail": "",
+    }
+    if resource is None:
+        result["status"] = "unknown_prefix"
+        result["detail"] = reference_detail or f"no Bioregistry record for {prefix!r}"
+        return result
+
+    preferred = resource.get("preferred_prefix") or resource.get("prefix") or ""
+    canonical_prefix = resource.get("prefix") or ""
+    result["preferred_prefix"] = preferred
+    result["pattern"] = resource.get("pattern") or ""
+    result["example"] = resource.get("example") or ""
+    result["name"] = resource.get("name") or ""
+    mappings = resource.get("mappings") or {}
+    result["ols_id"] = mappings.get("ols") or canonical_prefix
+
+    queried = prefix
+    accepted = {canonical_prefix.casefold(), preferred.casefold()} - {""}
+    if queried.casefold() not in accepted:
+        result["status"] = "synonym_prefix"
+        result["detail"] = f"{queried!r} is a synonym of preferred prefix {preferred}"
+
+    if local is None:
+        return result
+
+    matched = local_matches_pattern(local, result["pattern"] or None)
+    if matched is False or (reference_detail and "invalid identifier" in reference_detail):
+        result["status"] = "invalid_local"
+        result["detail"] = (
+            reference_detail
+            or f"{local!r} does not match pattern {result['pattern']}"
+        )
+        return result
+
+    canonical = f"{preferred}:{local}" if preferred else f"{canonical_prefix}:{local}"
+    result["canonical_curie"] = canonical
+    iri = apply_uri_format(resource.get("uri_format"), local)
+    result["default_iri"] = iri or ""
+    result["ontobee"] = ontobee_url(preferred, iri) or ""
+    result["identifiers_org"] = f"https://identifiers.org/{canonical}" if preferred else ""
+    return result

--- a/skills/ontology-term-resolution/scripts/id_client.py
+++ b/skills/ontology-term-resolution/scripts/id_client.py
@@ -21,8 +21,12 @@ Verified against the live APIs in September 2026 (see
 * ``/api/reference/{CURIE}`` validates the local id against ``pattern``. A
   404 body of ``{"detail": "invalid identifier: ..."}`` means the prefix is
   known and the local part is wrong — not that the prefix is unknown.
-* Identifiers.org rejects synonym prefixes (``HPO:0001250`` → HTTP 400).
-  Always resolve through the Bioregistry preferred prefix first.
+* Identifiers.org rejects synonym prefixes (``HPO:0001250`` → HTTP 400) and
+  also rejects Bioregistry's preferred prefix when that is not the MIRIAM
+  namespace (``ORPHA:558`` → 400; ``orphanet:558`` → 200). Landing pages
+  come from ``/api/reference/{CURIE}`` ``providers.miriam`` and the
+  registry ``mappings.ontobee`` field — never from templating
+  ``preferred_prefix``.
 """
 from __future__ import annotations
 
@@ -37,7 +41,7 @@ from typing import Any
 BIOREGISTRY_BASE = "https://bioregistry.io/api"
 IDENTIFIERS_RESOLVER = "https://resolver.api.identifiers.org"
 ONTOBEE_TERM = "https://ontobee.org/ontology/{prefix}?iri={iri}"
-USER_AGENT = "scientific-agent-skills-ontology-term-resolution/1.1"
+USER_AGENT = "scientific-agent-skills-ontology-term-resolution/1.2"
 TIMEOUT = 30
 MAX_ATTEMPTS = 3
 RETRY_STATUS = {429, 500, 502, 503, 504}
@@ -166,7 +170,10 @@ def local_matches_pattern(local: str, pattern: str | None) -> bool | None:
     """
     if not pattern:
         return None
-    return re.fullmatch(pattern, local) is not None
+    try:
+        return re.fullmatch(pattern, local) is not None
+    except re.error:
+        return None
 
 
 def apply_uri_format(uri_format: str | None, local: str) -> str | None:
@@ -176,18 +183,52 @@ def apply_uri_format(uri_format: str | None, local: str) -> str | None:
     return uri_format.replace("$1", local)
 
 
-def ontobee_url(preferred_prefix: str | None, iri: str | None) -> str | None:
+def ontobee_url(ontobee_prefix: str | None, iri: str | None) -> str | None:
     """Build the Ontobee HTML/RDF page for a term IRI.
 
-    Ontobee has no JSON search API. The page is the product: HTML for
-    humans, RDF when the same IRI is dereferenced as linked data.
+    ``ontobee_prefix`` is Bioregistry ``mappings.ontobee``, not
+    ``preferred_prefix``. Ontobee has no JSON search API. The page is the
+    product: HTML for humans, RDF when the same IRI is dereferenced as
+    linked data.
     """
-    if not preferred_prefix or not iri:
+    if not ontobee_prefix or not iri:
         return None
     return ONTOBEE_TERM.format(
-        prefix=preferred_prefix,
+        prefix=ontobee_prefix,
         iri=urllib.parse.quote(iri, safe=""),
     )
+
+
+def compact_id_from_identifiers_url(url: str) -> str | None:
+    """``https://identifiers.org/orphanet:558`` → ``orphanet:558``."""
+    if not url:
+        return None
+    path = urllib.parse.urlparse(url).path.lstrip("/")
+    return path or None
+
+
+def landing_page_urls(
+    resource: dict | None,
+    reference: dict | None,
+    iri: str | None,
+) -> tuple[str, str]:
+    """Return ``(identifiers_org, ontobee)`` from mappings, never templates.
+
+    Identifiers.org comes from ``/api/reference/{CURIE}`` ``providers.miriam``.
+    Ontobee comes from the registry ``mappings.ontobee`` field plus ``iri``.
+    Either side is empty when that mapping is missing — Bioregistry's
+    preferred prefix is not a substitute.
+    """
+    identifiers = ""
+    if reference:
+        providers = reference.get("providers") or {}
+        if isinstance(providers, dict):
+            identifiers = providers.get("miriam") or ""
+    ontobee = ""
+    if resource:
+        mappings = resource.get("mappings") or {}
+        ontobee = ontobee_url(mappings.get("ontobee"), iri) or ""
+    return identifiers, ontobee
 
 
 def identifiers_landing_pages(payload: dict) -> list[dict[str, Any]]:
@@ -271,6 +312,7 @@ def classify_prefix_query(
     result["canonical_curie"] = canonical
     iri = apply_uri_format(resource.get("uri_format"), local)
     result["default_iri"] = iri or ""
-    result["ontobee"] = ontobee_url(preferred, iri) or ""
-    result["identifiers_org"] = f"https://identifiers.org/{canonical}" if preferred else ""
+    # Landing pages are filled by the caller from /api/reference providers
+    # and mappings.ontobee. Templating preferred_prefix here emits dead URLs
+    # (ORPHA:558, OBA:0000001).
     return result

--- a/skills/ontology-term-resolution/scripts/lookup_prefix.py
+++ b/skills/ontology-term-resolution/scripts/lookup_prefix.py
@@ -28,10 +28,11 @@ from id_client import (  # noqa: E402
     IdError,
     NotFoundError,
     classify_prefix_query,
+    compact_id_from_identifiers_url,
     get_reference,
     get_resource,
-    identifiers_landing_pages,
     is_prefix,
+    landing_page_urls,
     resolve_identifiers,
     split_query,
 )
@@ -101,6 +102,7 @@ def lookup_one(value: str) -> dict:
         }
 
     resource = None
+    reference = None
     reference_detail = None
     try:
         resource = get_resource(prefix)
@@ -109,29 +111,37 @@ def lookup_one(value: str) -> dict:
 
     if local is not None:
         try:
-            get_reference(value)
+            reference = get_reference(value)
         except NotFoundError as exc:
             reference_detail = exc.detail
 
     result = classify_prefix_query(
         value, resource, local=local, reference_detail=reference_detail
     )
+    if result["status"] not in {"ok", "synonym_prefix"}:
+        return result
 
-    if result["canonical_curie"] and result["status"] in {"ok", "synonym_prefix"}:
-        try:
-            payload = resolve_identifiers(result["canonical_curie"])
-        except IdError:
-            payload = None
-        if payload:
-            if payload.get("errorMessage"):
-                extra = f"Identifiers.org rejected {result['canonical_curie']!r}: {payload['errorMessage']}"
-                result["detail"] = (
-                    f"{result['detail']}; {extra}" if result["detail"] else extra
-                )
-            else:
-                pages = identifiers_landing_pages(payload)
-                if pages and not result["identifiers_org"]:
-                    result["identifiers_org"] = pages[0]["url"]
+    identifiers, ontobee = landing_page_urls(
+        resource, reference, result["default_iri"] or None
+    )
+    result["identifiers_org"] = identifiers
+    result["ontobee"] = ontobee
+
+    compact = compact_id_from_identifiers_url(result["identifiers_org"])
+    if not compact:
+        return result
+
+    try:
+        payload = resolve_identifiers(compact)
+    except IdError:
+        result["identifiers_org"] = ""
+        extra = f"Identifiers.org rejected {compact!r}"
+        result["detail"] = f"{result['detail']}; {extra}" if result["detail"] else extra
+        return result
+    if payload.get("errorMessage"):
+        result["identifiers_org"] = ""
+        extra = f"Identifiers.org rejected {compact!r}: {payload['errorMessage']}"
+        result["detail"] = f"{result['detail']}; {extra}" if result["detail"] else extra
     return result
 
 

--- a/skills/ontology-term-resolution/scripts/lookup_prefix.py
+++ b/skills/ontology-term-resolution/scripts/lookup_prefix.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Look up ontology prefixes and check CURIEs against Bioregistry.
+
+Use this when the *shape* of an identifier is in doubt — ``HPO`` vs ``HP``,
+a local id that does not match the recorded pattern, or which landing page
+to open. It does not say whether the term exists; run ``validate_terms.py``
+for that.
+
+Examples:
+    uv run lookup_prefix.py HP HPO HP:0001250 HPO:0001250
+    uv run lookup_prefix.py --input prefixes.txt --format tsv
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from id_client import (  # noqa: E402
+    IdError,
+    NotFoundError,
+    classify_prefix_query,
+    get_reference,
+    get_resource,
+    identifiers_landing_pages,
+    is_prefix,
+    resolve_identifiers,
+    split_query,
+)
+
+TSV_COLUMNS = (
+    "query",
+    "status",
+    "preferred_prefix",
+    "canonical_curie",
+    "pattern",
+    "example",
+    "name",
+    "default_iri",
+    "identifiers_org",
+    "ontobee",
+    "ols_id",
+    "detail",
+)
+
+FAIL_STATUSES = {"unknown_prefix", "invalid_local", "malformed"}
+
+
+def read_inputs(args: argparse.Namespace) -> list[str]:
+    """Collect prefix/CURIE strings from positional args, a file, or stdin."""
+    values: list[str] = list(args.value)
+    if args.input:
+        raw = (
+            sys.stdin.read()
+            if args.input == "-"
+            else Path(args.input).read_text(encoding="utf-8")
+        )
+        for line in raw.splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                values.append(line)
+    if not values and not sys.stdin.isatty():
+        for line in sys.stdin.read().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                values.append(line)
+    seen: set[str] = set()
+    unique = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            unique.append(value)
+    return unique
+
+
+def lookup_one(value: str) -> dict:
+    """Resolve one prefix or CURIE through Bioregistry, then Identifiers.org."""
+    prefix, local = split_query(value)
+    if not is_prefix(prefix) and local is None:
+        return {
+            "query": value,
+            "status": "malformed",
+            "preferred_prefix": "",
+            "canonical_curie": "",
+            "pattern": "",
+            "example": "",
+            "name": "",
+            "default_iri": "",
+            "identifiers_org": "",
+            "ontobee": "",
+            "ols_id": "",
+            "detail": "not a prefix or PREFIX:local CURIE",
+        }
+
+    resource = None
+    reference_detail = None
+    try:
+        resource = get_resource(prefix)
+    except NotFoundError as exc:
+        return classify_prefix_query(value, None, local=local, reference_detail=exc.detail)
+
+    if local is not None:
+        try:
+            get_reference(value)
+        except NotFoundError as exc:
+            reference_detail = exc.detail
+
+    result = classify_prefix_query(
+        value, resource, local=local, reference_detail=reference_detail
+    )
+
+    if result["canonical_curie"] and result["status"] in {"ok", "synonym_prefix"}:
+        try:
+            payload = resolve_identifiers(result["canonical_curie"])
+        except IdError:
+            payload = None
+        if payload:
+            if payload.get("errorMessage"):
+                extra = f"Identifiers.org rejected {result['canonical_curie']!r}: {payload['errorMessage']}"
+                result["detail"] = (
+                    f"{result['detail']}; {extra}" if result["detail"] else extra
+                )
+            else:
+                pages = identifiers_landing_pages(payload)
+                if pages and not result["identifiers_org"]:
+                    result["identifiers_org"] = pages[0]["url"]
+    return result
+
+
+def write_output(results: list[dict], fmt: str, output: str | None) -> None:
+    stream = open(output, "w", encoding="utf-8", newline="") if output else sys.stdout
+    try:
+        if fmt == "json":
+            json.dump(results, stream, indent=2)
+            stream.write("\n")
+        else:
+            writer = csv.DictWriter(
+                stream, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n"
+            )
+            writer.writeheader()
+            writer.writerows(results)
+    finally:
+        if output:
+            stream.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Look up ontology prefixes and check CURIEs against Bioregistry. "
+            "Does not say whether the term exists — use validate_terms.py for that."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("value", nargs="*", help="prefixes or CURIEs")
+    parser.add_argument(
+        "--input",
+        help="file with one prefix or CURIE per line ('-' for stdin); # lines are comments",
+    )
+    parser.add_argument(
+        "--format", choices=("tsv", "json"), default="tsv", help="output format"
+    )
+    parser.add_argument("-o", "--output", help="write here instead of stdout")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    values = read_inputs(args)
+    if not values:
+        print("No prefixes or CURIEs given. See --help.", file=sys.stderr)
+        return 2
+
+    results = []
+    for value in values:
+        try:
+            results.append(lookup_one(value))
+        except IdError as exc:
+            print(f"Prefix lookup failed for {value!r}: {exc}", file=sys.stderr)
+            return 2
+
+    write_output(results, args.format, args.output)
+    failed = [r for r in results if r["status"] in FAIL_STATUSES]
+    synonyms = [r for r in results if r["status"] == "synonym_prefix"]
+    print(
+        f"{len(results)} checked, {len(failed)} failed, {len(synonyms)} synonym prefixes",
+        file=sys.stderr,
+    )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ontology-term-resolution/scripts/map_terms.py
+++ b/skills/ontology-term-resolution/scripts/map_terms.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Map lab shorthand to ontology terms via EBI ZOOMA.
+
+Use this after ``resolve_terms.py`` returns ``unresolved`` or only ``partial``
+hits on strings like ``PBMC`` or ``WT``. Every HIGH/GOOD hit is still only a
+candidate — run ``validate_terms.py`` on the CURIE before writing it down.
+
+``--ontology`` is required. Unfiltered ZOOMA annotate returns FOODON, XAO, and
+BTO alongside UBERON for ``liver``, all at HIGH confidence.
+
+Examples:
+    uv run map_terms.py PBMC --ontology cl
+    uv run map_terms.py liver --ontology uberon --property-type "organism part"
+    uv run map_terms.py --input shorthand.txt --ontology uberon,cl --exact-only
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from zooma_client import (  # noqa: E402
+    ZoomaError,
+    annotate,
+    flatten_hit,
+)
+
+TSV_COLUMNS = (
+    "query",
+    "rank",
+    "curie",
+    "iri",
+    "confidence",
+    "safe",
+    "evidence",
+    "source",
+    "property_type",
+    "match_type",
+)
+
+
+def read_inputs(args: argparse.Namespace) -> list[str]:
+    """Collect query strings from positional args, a file, or stdin."""
+    values: list[str] = list(args.text)
+    if args.input:
+        raw = (
+            sys.stdin.read()
+            if args.input == "-"
+            else Path(args.input).read_text(encoding="utf-8")
+        )
+        for line in raw.splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                values.append(line)
+    if not values and not sys.stdin.isatty():
+        for line in sys.stdin.read().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                values.append(line)
+    seen: set[str] = set()
+    unique = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            unique.append(value)
+    return unique
+
+
+def map_one(
+    text: str,
+    *,
+    ontologies: list[str],
+    property_type: str | None,
+    top: int,
+    safe_only: bool,
+) -> dict:
+    """Annotate one string and return ranked, flattened candidates."""
+    hits = annotate(text, ontologies=ontologies, property_type=property_type)
+    candidates: list[dict] = []
+    for hit in hits:
+        candidates.extend(flatten_hit(hit))
+    if safe_only:
+        candidates = [row for row in candidates if row["safe"]]
+    # HIGH before GOOD before MEDIUM/LOW; preserve server order within a tier.
+    rank = {"HIGH": 0, "GOOD": 1, "MEDIUM": 2, "LOW": 3}
+    candidates.sort(key=lambda row: rank.get(row["confidence"], 9))
+    return {"query": text, "candidates": candidates[:top]}
+
+
+def to_rows(results: list[dict]) -> list[dict]:
+    rows: list[dict] = []
+    for result in results:
+        if not result["candidates"]:
+            rows.append(
+                {
+                    "query": result["query"],
+                    "rank": 1,
+                    "curie": "",
+                    "iri": "",
+                    "confidence": "",
+                    "safe": "",
+                    "evidence": "",
+                    "source": "",
+                    "property_type": "",
+                    "match_type": "unresolved",
+                }
+            )
+            continue
+        for position, candidate in enumerate(result["candidates"], start=1):
+            rows.append(
+                {
+                    "query": result["query"],
+                    "rank": position,
+                    "curie": candidate["curie"],
+                    "iri": candidate["iri"],
+                    "confidence": candidate["confidence"],
+                    "safe": str(candidate["safe"]).lower(),
+                    "evidence": candidate["evidence"],
+                    "source": candidate["source"],
+                    "property_type": candidate["property_type"],
+                    "match_type": "zooma_safe" if candidate["safe"] else "zooma_weak",
+                }
+            )
+    return rows
+
+
+def write_output(results: list[dict], fmt: str, output: str | None) -> None:
+    stream = open(output, "w", encoding="utf-8", newline="") if output else sys.stdout
+    try:
+        if fmt == "json":
+            json.dump(results, stream, indent=2)
+            stream.write("\n")
+        else:
+            writer = csv.DictWriter(
+                stream, fieldnames=TSV_COLUMNS, delimiter="\t", lineterminator="\n"
+            )
+            writer.writeheader()
+            writer.writerows(to_rows(results))
+    finally:
+        if output:
+            stream.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Map lab shorthand to ontology terms via EBI ZOOMA. "
+            "--ontology is required. Validate every CURIE with validate_terms.py "
+            "before writing it down."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("text", nargs="*", help="strings to map")
+    parser.add_argument(
+        "--input",
+        help="file with one string per line ('-' for stdin); # lines are comments",
+    )
+    parser.add_argument(
+        "--ontology",
+        required=True,
+        help="OLS ontology ids to filter on, comma separated (e.g. uberon,cl)",
+    )
+    parser.add_argument(
+        "--property-type",
+        help='ZOOMA property type, e.g. "organism part" or "cell type"',
+    )
+    parser.add_argument(
+        "--top", type=int, default=5, help="candidates to report per query (default 5)"
+    )
+    parser.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="only HIGH/GOOD confidence hits; report anything else as unresolved",
+    )
+    parser.add_argument(
+        "--format", choices=("tsv", "json"), default="tsv", help="output format"
+    )
+    parser.add_argument("-o", "--output", help="write here instead of stdout")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    queries = read_inputs(args)
+    if not queries:
+        print("No input strings given. See --help.", file=sys.stderr)
+        return 2
+
+    ontologies = [item.strip() for item in args.ontology.split(",") if item.strip()]
+    if not ontologies:
+        print("--ontology needs at least one OLS ontology id.", file=sys.stderr)
+        return 2
+
+    results = []
+    for query in queries:
+        try:
+            results.append(
+                map_one(
+                    query,
+                    ontologies=ontologies,
+                    property_type=args.property_type,
+                    top=args.top,
+                    safe_only=args.exact_only,
+                )
+            )
+        except ZoomaError as exc:
+            print(f"ZOOMA lookup failed for {query!r}: {exc}", file=sys.stderr)
+            return 2
+
+    write_output(results, args.format, args.output)
+    unresolved = [r["query"] for r in results if not r["candidates"]]
+    if unresolved:
+        print(
+            f"{len(unresolved)}/{len(results)} unresolved: "
+            + ", ".join(repr(q) for q in unresolved[:10]),
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ontology-term-resolution/scripts/ols_client.py
+++ b/skills/ontology-term-resolution/scripts/ols_client.py
@@ -30,7 +30,7 @@ import urllib.request
 from typing import Any, Iterable
 
 OLS_BASE = "https://www.ebi.ac.uk/ols4/api"
-USER_AGENT = "scientific-agent-skills-ontology-term-resolution/1.1"
+USER_AGENT = "scientific-agent-skills-ontology-term-resolution/1.2"
 TIMEOUT = 30
 MAX_ATTEMPTS = 3
 RETRY_STATUS = {429, 500, 502, 503, 504}

--- a/skills/ontology-term-resolution/scripts/ols_client.py
+++ b/skills/ontology-term-resolution/scripts/ols_client.py
@@ -30,7 +30,7 @@ import urllib.request
 from typing import Any, Iterable
 
 OLS_BASE = "https://www.ebi.ac.uk/ols4/api"
-USER_AGENT = "scientific-agent-skills-ontology-term-resolution/1.0"
+USER_AGENT = "scientific-agent-skills-ontology-term-resolution/1.1"
 TIMEOUT = 30
 MAX_ATTEMPTS = 3
 RETRY_STATUS = {429, 500, 502, 503, 504}

--- a/skills/ontology-term-resolution/scripts/zooma_client.py
+++ b/skills/ontology-term-resolution/scripts/zooma_client.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""EBI ZOOMA annotate client.
+
+ZOOMA maps free text to ontology IRIs using curated annotation history. It is
+a fallback when OLS lexical search fails on lab shorthand (``PBMC``, ``WT``),
+not a replacement for OLS.
+
+Unfiltered annotate is unusable — ``propertyValue=liver`` returns FOODON,
+XAO, BTO, and UBERON as equally HIGH hits. Always pass an ontology filter.
+
+Standard library only. Reuses ``iri_to_curie`` from ``ols_client`` so IRI
+shapes stay consistent with the rest of the skill.
+"""
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from ols_client import iri_to_curie
+
+ZOOMA_ANNOTATE = "https://www.ebi.ac.uk/spot/zooma/v2/api/services/annotate"
+USER_AGENT = "scientific-agent-skills-ontology-term-resolution/1.1"
+TIMEOUT = 60
+MAX_ATTEMPTS = 3
+RETRY_STATUS = {429, 500, 502, 503, 504}
+
+# HIGH and GOOD are curator-grade. MEDIUM and LOW are guesses — report them,
+# but do not treat them as ready to write into metadata.
+SAFE_CONFIDENCE = {"HIGH", "GOOD"}
+
+
+class ZoomaError(RuntimeError):
+    """A request to ZOOMA failed in a way the caller cannot paper over."""
+
+
+def ontology_filter(ontologies: list[str]) -> str:
+    """Build the ``filter`` query value ZOOMA requires.
+
+    ``required:[none]`` keeps the call from demanding a datasources list.
+    Ontology ids are lowercase OLS ids (``uberon``, ``cl``), not prefixes.
+    """
+    ids = ",".join(item.strip().lower() for item in ontologies if item.strip())
+    if not ids:
+        raise ZoomaError("ZOOMA annotate requires at least one ontology id")
+    return f"required:[none],ontologies:[{ids}]"
+
+
+def annotate(
+    text: str,
+    *,
+    ontologies: list[str],
+    property_type: str | None = None,
+) -> list[dict]:
+    """Call ``/annotate`` and return the raw hit list.
+
+    ``ontologies`` is required. Calling this without a filter is how you get
+    ``FOODON:03309772`` for ``liver``.
+    """
+    params: dict[str, Any] = {
+        "propertyValue": text,
+        "filter": ontology_filter(ontologies),
+    }
+    if property_type:
+        params["propertyType"] = property_type
+    url = f"{ZOOMA_ANNOTATE}?{urllib.parse.urlencode(params)}"
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, "Accept": "application/json"})
+
+    last: Exception | None = None
+    for attempt in range(MAX_ATTEMPTS):
+        try:
+            with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+                payload = json.load(response)
+            if not isinstance(payload, list):
+                raise ZoomaError(f"ZOOMA returned a non-list body for {text!r}")
+            return payload
+        except urllib.error.HTTPError as exc:
+            last = exc
+            if exc.code not in RETRY_STATUS:
+                raise ZoomaError(f"ZOOMA HTTP {exc.code} for {text!r}") from exc
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            last = exc
+        if attempt < MAX_ATTEMPTS - 1:
+            time.sleep(1.5 * (attempt + 1))
+    raise ZoomaError(f"ZOOMA request failed after {MAX_ATTEMPTS} attempts: {url} ({last})")
+
+
+def flatten_hit(hit: dict) -> list[dict]:
+    """Turn one ZOOMA annotation into one row per semantic tag."""
+    confidence = (hit.get("confidence") or "").upper()
+    prop = hit.get("annotatedProperty") or {}
+    provenance = hit.get("provenance") or {}
+    source = provenance.get("source") or {}
+    rows = []
+    tags = hit.get("semanticTags") or []
+    if not tags:
+        return [
+            {
+                "iri": "",
+                "curie": "",
+                "confidence": confidence or "UNKNOWN",
+                "safe": False,
+                "evidence": provenance.get("evidence") or "",
+                "source": source.get("name") or "",
+                "property_type": prop.get("propertyType") or "",
+                "property_value": prop.get("propertyValue") or "",
+            }
+        ]
+    for iri in tags:
+        iri = str(iri)
+        rows.append(
+            {
+                "iri": iri,
+                "curie": iri_to_curie(iri) or "",
+                "confidence": confidence or "UNKNOWN",
+                "safe": confidence in SAFE_CONFIDENCE,
+                "evidence": provenance.get("evidence") or "",
+                "source": source.get("name") or "",
+                "property_type": prop.get("propertyType") or "",
+                "property_value": prop.get("propertyValue") or "",
+            }
+        )
+    return rows

--- a/skills/ontology-term-resolution/scripts/zooma_client.py
+++ b/skills/ontology-term-resolution/scripts/zooma_client.py
@@ -27,7 +27,7 @@ from typing import Any
 from ols_client import iri_to_curie
 
 ZOOMA_ANNOTATE = "https://www.ebi.ac.uk/spot/zooma/v2/api/services/annotate"
-USER_AGENT = "scientific-agent-skills-ontology-term-resolution/1.1"
+USER_AGENT = "scientific-agent-skills-ontology-term-resolution/1.2"
 TIMEOUT = 60
 MAX_ATTEMPTS = 3
 RETRY_STATUS = {429, 500, 502, 503, 504}

--- a/tests/ontology-term-resolution/test_scripts.py
+++ b/tests/ontology-term-resolution/test_scripts.py
@@ -456,6 +456,37 @@ HP_RESOURCE = {
     "mappings": {"ols": "hp", "ontobee": "HP", "miriam": "hp"},
 }
 
+CHEBI_RESOURCE = {
+    "prefix": "chebi",
+    "preferred_prefix": "CHEBI",
+    "name": "Chemical Entities of Biological Interest",
+    "pattern": r"^\d+$",
+    "example": "3698",
+    "uri_format": "http://purl.obolibrary.org/obo/CHEBI_$1",
+    "mappings": {"ols": "chebi", "ontobee": "CHEBI", "miriam": "chebi"},
+}
+
+ORPHA_RESOURCE = {
+    "prefix": "orpha",
+    "preferred_prefix": "ORPHA",
+    "name": "Orphanet Rare Disease Ontology",
+    "pattern": r"^\d+$",
+    "example": "189564",
+    "uri_format": "http://www.orpha.net/ORDO/Orphanet_$1",
+    "synonyms": ["orphanet"],
+    "mappings": {"ols": "ordo", "miriam": "orphanet"},
+}
+
+OBA_RESOURCE = {
+    "prefix": "oba",
+    "preferred_prefix": "OBA",
+    "name": "Ontology of Biological Attributes",
+    "pattern": r"^\d{7}$",
+    "example": "0000001",
+    "uri_format": "http://purl.obolibrary.org/obo/OBA_$1",
+    "mappings": {"ols": "oba", "ontobee": "OBA"},
+}
+
 
 class PrefixHelperTests(unittest.TestCase):
     def test_split_query_handles_prefix_and_curie(self):
@@ -470,6 +501,10 @@ class PrefixHelperTests(unittest.TestCase):
             "the Bioregistry pattern applies to the local id, not the CURIE",
         )
         self.assertIsNone(id_client.local_matches_pattern("0001250", None))
+        self.assertIsNone(
+            id_client.local_matches_pattern("0001250", r"(unclosed"),
+            "an uncompilable Bioregistry pattern is unchecked, not a crash",
+        )
 
     def test_uri_format_and_ontobee_url(self):
         iri = id_client.apply_uri_format(HP_RESOURCE["uri_format"], "0001250")
@@ -519,6 +554,52 @@ class PrefixHelperTests(unittest.TestCase):
         self.assertEqual(result["status"], "invalid_local")
         self.assertIn("invalid identifier", result["detail"])
 
+    def test_classify_does_not_template_landing_pages(self):
+        result = id_client.classify_prefix_query(
+            "orphanet:558", ORPHA_RESOURCE, local="558"
+        )
+        self.assertEqual(result["canonical_curie"], "ORPHA:558")
+        self.assertEqual(result["identifiers_org"], "")
+        self.assertEqual(result["ontobee"], "")
+
+    def test_landing_pages_hp_uses_miriam_and_ontobee_mapping(self):
+        identifiers, ontobee = id_client.landing_page_urls(
+            HP_RESOURCE,
+            {"providers": {"miriam": "https://identifiers.org/HP:0001250"}},
+            "http://purl.obolibrary.org/obo/HP_0001250",
+        )
+        self.assertEqual(identifiers, "https://identifiers.org/HP:0001250")
+        self.assertTrue(ontobee.startswith("https://ontobee.org/ontology/HP?iri="))
+
+    def test_landing_pages_chebi_keeps_embedded_prefix(self):
+        identifiers, ontobee = id_client.landing_page_urls(
+            CHEBI_RESOURCE,
+            {"providers": {"miriam": "https://identifiers.org/CHEBI:15377"}},
+            "http://purl.obolibrary.org/obo/CHEBI_15377",
+        )
+        self.assertEqual(identifiers, "https://identifiers.org/CHEBI:15377")
+        self.assertNotIn("chebi:15377", identifiers)
+        self.assertTrue(ontobee.startswith("https://ontobee.org/ontology/CHEBI?iri="))
+
+    def test_landing_pages_orphanet_uses_miriam_namespace_not_preferred(self):
+        identifiers, ontobee = id_client.landing_page_urls(
+            ORPHA_RESOURCE,
+            {"providers": {"miriam": "https://identifiers.org/orphanet:558"}},
+            "http://www.orpha.net/ORDO/Orphanet_558",
+        )
+        self.assertEqual(identifiers, "https://identifiers.org/orphanet:558")
+        self.assertNotIn("ORPHA", identifiers)
+        self.assertEqual(ontobee, "")
+
+    def test_landing_pages_oba_has_no_identifiers_org(self):
+        identifiers, ontobee = id_client.landing_page_urls(
+            OBA_RESOURCE,
+            {"providers": {}},
+            "http://purl.obolibrary.org/obo/OBA_0000001",
+        )
+        self.assertEqual(identifiers, "")
+        self.assertTrue(ontobee.startswith("https://ontobee.org/ontology/OBA?iri="))
+
 
 class LookupPrefixCliTests(unittest.TestCase):
     def test_malformed_input_does_not_hit_the_network(self):
@@ -529,15 +610,80 @@ class LookupPrefixCliTests(unittest.TestCase):
 
     def test_lookup_uses_bioregistry_then_identifiers(self):
         with patch.object(lookup_prefix, "get_resource", return_value=HP_RESOURCE), \
-             patch.object(lookup_prefix, "get_reference", return_value={"providers": {}}), \
+             patch.object(
+                 lookup_prefix,
+                 "get_reference",
+                 return_value={"providers": {"miriam": "https://identifiers.org/HP:0001250"}},
+             ), \
              patch.object(
                  lookup_prefix,
                  "resolve_identifiers",
                  return_value={"errorMessage": None, "payload": {"resolvedResources": []}},
-             ):
+             ) as resolve:
             result = lookup_prefix.lookup_one("HP:0001250")
+        resolve.assert_called_once_with("HP:0001250")
         self.assertEqual(result["status"], "ok")
         self.assertEqual(result["canonical_curie"], "HP:0001250")
+        self.assertEqual(result["identifiers_org"], "https://identifiers.org/HP:0001250")
+        self.assertTrue(result["ontobee"].startswith("https://ontobee.org/ontology/HP?"))
+
+    def test_lookup_orphanet_emits_miriam_url_not_preferred_prefix(self):
+        with patch.object(lookup_prefix, "get_resource", return_value=ORPHA_RESOURCE), \
+             patch.object(
+                 lookup_prefix,
+                 "get_reference",
+                 return_value={"providers": {"miriam": "https://identifiers.org/orphanet:558"}},
+             ), \
+             patch.object(
+                 lookup_prefix,
+                 "resolve_identifiers",
+                 return_value={"errorMessage": None, "payload": {"resolvedResources": []}},
+             ) as resolve:
+            result = lookup_prefix.lookup_one("orphanet:558")
+        resolve.assert_called_once_with("orphanet:558")
+        self.assertEqual(result["identifiers_org"], "https://identifiers.org/orphanet:558")
+        self.assertEqual(result["ontobee"], "")
+
+    def test_lookup_oba_leaves_identifiers_org_empty(self):
+        with patch.object(lookup_prefix, "get_resource", return_value=OBA_RESOURCE), \
+             patch.object(lookup_prefix, "get_reference", return_value={"providers": {}}), \
+             patch.object(lookup_prefix, "resolve_identifiers") as resolve:
+            result = lookup_prefix.lookup_one("OBA:0000001")
+        resolve.assert_not_called()
+        self.assertEqual(result["identifiers_org"], "")
+        self.assertTrue(result["ontobee"].startswith("https://ontobee.org/ontology/OBA?"))
+
+    def test_lookup_chebi_keeps_embedded_prefix_in_miriam_url(self):
+        with patch.object(lookup_prefix, "get_resource", return_value=CHEBI_RESOURCE), \
+             patch.object(
+                 lookup_prefix,
+                 "get_reference",
+                 return_value={"providers": {"miriam": "https://identifiers.org/CHEBI:15377"}},
+             ), \
+             patch.object(
+                 lookup_prefix,
+                 "resolve_identifiers",
+                 return_value={"errorMessage": None, "payload": {"resolvedResources": []}},
+             ) as resolve:
+            result = lookup_prefix.lookup_one("CHEBI:15377")
+        resolve.assert_called_once_with("CHEBI:15377")
+        self.assertEqual(result["identifiers_org"], "https://identifiers.org/CHEBI:15377")
+
+    def test_lookup_blanks_identifiers_org_when_resolver_rejects(self):
+        with patch.object(lookup_prefix, "get_resource", return_value=HP_RESOURCE), \
+             patch.object(
+                 lookup_prefix,
+                 "get_reference",
+                 return_value={"providers": {"miriam": "https://identifiers.org/HP:0001250"}},
+             ), \
+             patch.object(
+                 lookup_prefix,
+                 "resolve_identifiers",
+                 return_value={"errorMessage": "NOT A NAMESPACE", "payload": None},
+             ):
+            result = lookup_prefix.lookup_one("HP:0001250")
+        self.assertEqual(result["identifiers_org"], "")
+        self.assertIn("NOT A NAMESPACE", result["detail"])
 
     def test_unknown_prefix_from_404(self):
         with patch.object(

--- a/tests/ontology-term-resolution/test_scripts.py
+++ b/tests/ontology-term-resolution/test_scripts.py
@@ -42,6 +42,10 @@ def _load_script(name: str):
 ols_client = _load_script("ols_client")
 resolve_terms = _load_script("resolve_terms")
 validate_terms = _load_script("validate_terms")
+id_client = _load_script("id_client")
+lookup_prefix = _load_script("lookup_prefix")
+zooma_client = _load_script("zooma_client")
+map_terms = _load_script("map_terms")
 
 
 def doc(**overrides):
@@ -439,6 +443,187 @@ class ExitCodeTests(unittest.TestCase):
             ["UBERON:0002107", "--format", "json"], [self.result("ok")]
         )
         self.assertEqual(json.loads(output)[0]["status"], "ok")
+
+
+HP_RESOURCE = {
+    "prefix": "hp",
+    "preferred_prefix": "HP",
+    "name": "Human Phenotype Ontology",
+    "pattern": r"^\d{7}$",
+    "example": "0011140",
+    "uri_format": "http://purl.obolibrary.org/obo/HP_$1",
+    "synonyms": ["hpo"],
+    "mappings": {"ols": "hp", "ontobee": "HP", "miriam": "hp"},
+}
+
+
+class PrefixHelperTests(unittest.TestCase):
+    def test_split_query_handles_prefix_and_curie(self):
+        self.assertEqual(id_client.split_query("HP"), ("HP", None))
+        self.assertEqual(id_client.split_query("HP:0001250"), ("HP", "0001250"))
+        self.assertEqual(id_client.split_query("  HPO:0001250 "), ("HPO", "0001250"))
+
+    def test_local_pattern_is_the_local_id_only(self):
+        self.assertTrue(id_client.local_matches_pattern("0001250", r"^\d{7}$"))
+        self.assertFalse(
+            id_client.local_matches_pattern("HP:0001250", r"^\d{7}$"),
+            "the Bioregistry pattern applies to the local id, not the CURIE",
+        )
+        self.assertIsNone(id_client.local_matches_pattern("0001250", None))
+
+    def test_uri_format_and_ontobee_url(self):
+        iri = id_client.apply_uri_format(HP_RESOURCE["uri_format"], "0001250")
+        self.assertEqual(iri, "http://purl.obolibrary.org/obo/HP_0001250")
+        page = id_client.ontobee_url("HP", iri)
+        self.assertTrue(page.startswith("https://ontobee.org/ontology/HP?iri="))
+        self.assertIn("HP_0001250", page)
+
+    def test_identifiers_resolver_url_keeps_the_colon(self):
+        url = id_client.identifiers_resolver_url("HP:0001250")
+        self.assertEqual(url, "https://resolver.api.identifiers.org/HP:0001250")
+        self.assertNotIn("%3A", url)
+
+    def test_preferred_prefix_is_ok_in_either_case(self):
+        for query in ("HP", "hp"):
+            result = id_client.classify_prefix_query(query, HP_RESOURCE, local=None)
+            self.assertEqual(result["status"], "ok", query)
+            self.assertEqual(result["preferred_prefix"], "HP")
+
+    def test_synonym_prefix_is_flagged(self):
+        result = id_client.classify_prefix_query("HPO", HP_RESOURCE, local=None)
+        self.assertEqual(result["status"], "synonym_prefix")
+        self.assertIn("preferred prefix HP", result["detail"])
+
+    def test_synonym_curie_still_builds_the_preferred_form(self):
+        result = id_client.classify_prefix_query("HPO:0001250", HP_RESOURCE, local="0001250")
+        self.assertEqual(result["status"], "synonym_prefix")
+        self.assertEqual(result["canonical_curie"], "HP:0001250")
+        self.assertEqual(result["default_iri"], "http://purl.obolibrary.org/obo/HP_0001250")
+
+    def test_invalid_local_id_is_caught_without_a_network_call(self):
+        result = id_client.classify_prefix_query("HP:notanid", HP_RESOURCE, local="notanid")
+        self.assertEqual(result["status"], "invalid_local")
+        self.assertEqual(result["canonical_curie"], "")
+
+    def test_unknown_prefix(self):
+        result = id_client.classify_prefix_query("NOTAREAL", None, local=None)
+        self.assertEqual(result["status"], "unknown_prefix")
+
+    def test_reference_detail_overrides_for_invalid_local(self):
+        result = id_client.classify_prefix_query(
+            "HP:abc",
+            HP_RESOURCE,
+            local="abc",
+            reference_detail="invalid identifier: hp:abc for pattern ^\\d{7}$",
+        )
+        self.assertEqual(result["status"], "invalid_local")
+        self.assertIn("invalid identifier", result["detail"])
+
+
+class LookupPrefixCliTests(unittest.TestCase):
+    def test_malformed_input_does_not_hit_the_network(self):
+        with patch.object(lookup_prefix, "get_resource") as fetch:
+            result = lookup_prefix.lookup_one("not a curie!!!")
+        fetch.assert_not_called()
+        self.assertEqual(result["status"], "malformed")
+
+    def test_lookup_uses_bioregistry_then_identifiers(self):
+        with patch.object(lookup_prefix, "get_resource", return_value=HP_RESOURCE), \
+             patch.object(lookup_prefix, "get_reference", return_value={"providers": {}}), \
+             patch.object(
+                 lookup_prefix,
+                 "resolve_identifiers",
+                 return_value={"errorMessage": None, "payload": {"resolvedResources": []}},
+             ):
+            result = lookup_prefix.lookup_one("HP:0001250")
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["canonical_curie"], "HP:0001250")
+
+    def test_unknown_prefix_from_404(self):
+        with patch.object(
+            lookup_prefix,
+            "get_resource",
+            side_effect=id_client.NotFoundError("Prefix not found: xyz", "url"),
+        ):
+            result = lookup_prefix.lookup_one("xyz")
+        self.assertEqual(result["status"], "unknown_prefix")
+
+    def test_no_input_exits_two(self):
+        # pytest captures stdin, so isatty() is False unless we force a TTY.
+        with patch.object(sys.stdin, "isatty", return_value=True), \
+             redirect_stdout(io.StringIO()):
+            self.assertEqual(lookup_prefix.main([]), 2)
+
+
+class ZoomaHelperTests(unittest.TestCase):
+    def test_filter_requires_an_ontology(self):
+        with self.assertRaises(zooma_client.ZoomaError):
+            zooma_client.ontology_filter([])
+        self.assertEqual(
+            zooma_client.ontology_filter(["UBERON", "CL"]),
+            "required:[none],ontologies:[uberon,cl]",
+        )
+
+    def test_flatten_hit_converts_obo_iris_and_flags_weak_confidence(self):
+        hit = {
+            "confidence": "MEDIUM",
+            "semanticTags": ["http://purl.obolibrary.org/obo/CL_2000001"],
+            "annotatedProperty": {"propertyType": "unspecified", "propertyValue": "PBMC"},
+            "provenance": {
+                "evidence": "OLS_TEXT_TAGGER",
+                "source": {"name": "cl"},
+            },
+        }
+        rows = zooma_client.flatten_hit(hit)
+        self.assertEqual(rows[0]["curie"], "CL:2000001")
+        self.assertFalse(rows[0]["safe"])
+        self.assertEqual(rows[0]["confidence"], "MEDIUM")
+
+    def test_high_confidence_is_safe(self):
+        hit = {
+            "confidence": "HIGH",
+            "semanticTags": ["http://purl.obolibrary.org/obo/UBERON_0002107"],
+            "annotatedProperty": {},
+            "provenance": {},
+        }
+        self.assertTrue(zooma_client.flatten_hit(hit)[0]["safe"])
+
+
+class MapTermsTests(unittest.TestCase):
+    def test_safe_only_drops_weak_hits(self):
+        hits = [
+            {
+                "confidence": "HIGH",
+                "semanticTags": ["http://purl.obolibrary.org/obo/CL_2000001"],
+                "annotatedProperty": {},
+                "provenance": {},
+            },
+            {
+                "confidence": "MEDIUM",
+                "semanticTags": ["http://purl.obolibrary.org/obo/CL_0000784"],
+                "annotatedProperty": {},
+                "provenance": {},
+            },
+        ]
+        with patch.object(map_terms, "annotate", return_value=hits):
+            result = map_terms.map_one(
+                "PBMC", ontologies=["cl"], property_type=None, top=5, safe_only=True
+            )
+        self.assertEqual([c["curie"] for c in result["candidates"]], ["CL:2000001"])
+
+    def test_unresolved_row_has_no_curie(self):
+        rows = map_terms.to_rows([{"query": "zzz", "candidates": []}])
+        self.assertEqual(rows[0]["match_type"], "unresolved")
+        self.assertEqual(rows[0]["curie"], "")
+
+    def test_missing_ontology_exits_two(self):
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(map_terms.main(["PBMC", "--ontology", ""]), 2)
+
+    def test_no_input_exits_two(self):
+        with patch.object(sys.stdin, "isatty", return_value=True), \
+             redirect_stdout(io.StringIO()):
+            self.assertEqual(map_terms.main(["--ontology", "cl"]), 2)
 
 
 @unittest.skipUnless(LIVE, "set OLS_LIVE_TESTS=1 to run tests that call EBI OLS")


### PR DESCRIPTION
## Summary
- Extend `ontology-term-resolution` (v1.0 → v1.1) with Bioregistry, Identifiers.org, ZOOMA, and Ontobee helpers. OLS remains the only authority for emitting or validating a term.
- `lookup_prefix.py` answers prefix/CURIE *shape* questions (`HPO` vs `HP`, local-id pattern, landing pages). `map_terms.py` maps lab shorthand after OLS lexical search misses; `--ontology` is required because unfiltered ZOOMA returns FOODON/XAO/BTO at HIGH for `liver`.
- Documented live-API traps in `references/companion-apis.md`, including Identifiers.org rejecting synonym prefixes and `%3A`-encoded colons.

@TKassis — requesting your review.

## Test plan
- [x] `uv run skills-ref validate skills/ontology-term-resolution`
- [x] `uv run --with pytest python -m pytest tests/ontology-term-resolution -q` (75 passed, 6 live OLS tests skipped)
- [x] `uv run --with pytest python -m pytest tests/_meta -q`
- [x] Live `lookup_prefix.py HP HPO HP:0001250 HPO:0001250 HP:notanid` — synonym rewrite, invalid local id, Identifiers.org colon kept unencoded
- [x] Live `map_terms.py PBMC --ontology cl --exact-only` → `CL:2000001` HIGH; `validate_terms.py CL:2000001` → `ok` (peripheral blood mononuclear cell)
- [ ] Reviewer: skim `SKILL.md` “Which service” table and confirm OLS-still-decides is the contract you want


Made with [Cursor](https://cursor.com)