### PR TITLE
Add companion literature APIs to paper-lookup

### DIFF
--- a/skills/paper-lookup/SKILL.md
+++ b/skills/paper-lookup/SKILL.md
@@ -1,27 +1,27 @@
 ---
 name: paper-lookup
-description: Search 11 academic literature APIs for papers, preprints, citations, and open-access full text, and return results with reproducible provenance. Covers PubMed, PMC (full text), Europe PMC (full-text and preprint search), bioRxiv, medRxiv, arXiv, OpenAlex, Crossref, Semantic Scholar, CORE, Unpaywall. Use when searching for papers, citations, DOI/PMID/arXiv lookups, abstracts, full text, open-access PDFs, preprints, citation graphs, author publications, or any scholarly literature query. Triggers on mentions of any supported database or requests like "find papers on X", "look up this DOI", "who cites this paper", or "get me the PDF".
+description: Search 18 scholarly APIs for papers, preprints, citations, open-access full text, repository records, and journal OA status, and return results with reproducible provenance. Covers PubMed, PMC, Europe PMC, bioRxiv, medRxiv, arXiv, OpenAlex, Crossref, Semantic Scholar, CORE, Unpaywall, OpenCitations, PubTator3, Zenodo, Figshare, ROR, BioStudies, and DOAJ. Use when searching for papers, citations, DOI/PMID/arXiv lookups, abstracts, full text, open-access PDFs, preprints, citation graphs, author publications, biomedical entity annotations, deposited records (Zenodo, Figshare, BioStudies), institution ROR IDs, or any scholarly literature query. Triggers on mentions of any supported database or requests like "find papers on X", "look up this DOI", "who cites this paper", or "get me the PDF".
 allowed-tools: Read Bash
 license: MIT
 compatibility: Needs network access and curl. The bundled scripts require Python 3.11+ and use only the standard library. No credentials are required; NCBI_API_KEY, S2_API_KEY, CORE_API_KEY, and OPENALEX_API_KEY raise rate limits or unlock full text where noted.
 metadata:
-  version: "2.1"
+  version: "2.2"
   skill-author: "K-Dense Inc."
 ---
 
 # Paper Lookup
 
-This skill gives you 11 academic literature APIs with documented endpoints. Your job is to turn the user's intent into a reproducible retrieval: pick the authoritative database(s), make bounded and rate-limited calls, and return an answer with enough provenance (endpoints, parameters, identifiers, access date) that a human or another agent can repeat it.
+This skill gives you 18 scholarly APIs with documented endpoints. Your job is to turn the user's intent into a reproducible retrieval: pick the authoritative database(s), make bounded and rate-limited calls, and return an answer with enough provenance (endpoints, parameters, identifiers, access date) that a human or another agent can repeat it.
 
 A literature lookup is only as trustworthy as it is repeatable. Prefer explicit identifiers and documented endpoints over broad guessing, report what you queried, and say plainly when a result is partial or a database came back empty — a silent gap reads as "nothing exists" when it may just mean "not indexed here."
 
-**These APIs fail with HTTP 200.** That is the recurring hazard across all eleven, and the reason for most of the rules below. PMC eFetch returns a well-formed article with no `<body>` when the publisher forbids redistribution. arXiv returns `totalResults: 1` and one entry titled `Error` for a malformed parameter, and silently rewrites an unknown field prefix to `all:`. Europe PMC puts `errCode` in a 200 body. bioRxiv accepts an out-of-step pagination cursor and returns the wrong 30 records. None of these raise, and every one of them produces a confident, wrong answer. Verify the shape of what you got, not just the status code.
+**These APIs fail with HTTP 200.** That is the recurring hazard, and the reason for most of the rules below. PMC eFetch returns a well-formed article with no `<body>` when the publisher forbids redistribution. arXiv returns `totalResults: 1` and one entry titled `Error` for a malformed parameter, and silently rewrites an unknown field prefix to `all:`. Europe PMC puts `errCode` in a 200 body. bioRxiv accepts an out-of-step pagination cursor and returns the wrong 30 records. Figshare `GET /articles?search_for=` ignores the query and still 200s. OpenCitations answers an unknown DOI with `[{"count": "0"}]`. None of these raise, and every one of them produces a confident, wrong answer. Verify the shape of what you got, not just the status code.
 
 ## Core Workflow
 
 1. **Define the retrieval contract** — What is the user after? A specific paper by DOI/PMID/arXiv ID? Papers on a topic? An author's publications? A citation graph? An open-access PDF? Full text? Note any constraints that change the answer: date range, field of study, open-access-only, exhaustive list vs. a few top hits. If a constraint that affects correctness is missing (e.g., "recent" with no year, or an author name with many namesakes), ask rather than guess.
 
-2. **Select database(s)** — Use the selection guide below. Route to the primary database for the intent, then add others only when they earn their place: identifier resolution, open-access lookup, or a known coverage gap. Don't fan out across all eleven just because they're available.
+2. **Select database(s)** — Use the selection guide below. Route to the primary database for the intent, then add others only when they earn their place: identifier resolution, open-access lookup, or a known coverage gap. Don't fan out across all eighteen just because they're available.
 
 3. **Read the reference file** — Each database has a file in `references/` with endpoints, parameters, example calls, response shapes, and **the specific ways it fails quietly**. Read the relevant file(s) before calling. The hazard sections are not optional background; they are where the wrong answers come from.
 
@@ -51,7 +51,8 @@ Match the user's intent to the right database(s).
 | Papers across all fields | OpenAlex | Semantic Scholar, Crossref |
 | A specific paper by DOI | Crossref | Unpaywall, Semantic Scholar |
 | Open-access PDF for a paper | Unpaywall | CORE, PMC |
-| Citation graph (who cites whom) | Semantic Scholar | OpenAlex, Europe PMC |
+| Citation graph (who cites whom) | Semantic Scholar | OpenAlex, Europe PMC, OpenCitations |
+| Open citation edges / OCI | OpenCitations | Semantic Scholar, Europe PMC |
 | Author's publications | Semantic Scholar | OpenAlex |
 | Paper recommendations | Semantic Scholar | — |
 | Full text (any field) | CORE | PMC, Europe PMC (biomedical only) |
@@ -59,12 +60,19 @@ Match the user's intent to the right database(s).
 | Funder information | Crossref | OpenAlex |
 | Convert between PMID/PMCID/DOI | PMC (ID Converter) | Crossref, Europe PMC |
 | Is this paper retracted? | PMC OA Web Service (`retracted` attribute) | Crossref (`update-type:retraction`) |
+| Genes/diseases/chemicals in a paper | PubTator3 | Europe PMC `textMinedTerms` |
+| Institution / affiliation → ROR ID | ROR | OpenAlex (already-linked ROR) |
+| Deposited dataset, software, or poster | Zenodo | Figshare, BioStudies |
+| EBI study package / supplementary archive | BioStudies | Zenodo, ArrayExpress via BioStudies |
+| Is this *journal* in DOAJ? | DOAJ | OpenAlex (`sources.is_in_doaj`) for the yes/no; Unpaywall (article-level OA) |
 
 ### Cross-Database Queries
 
 | User is asking about... | Databases to query |
 |---|---|
 | Everything about a paper (metadata + citations + OA) | Crossref + Semantic Scholar + Unpaywall |
+| Entities mentioned in a paper | PubTator3 export + PubMed/Europe PMC for the record |
+| Affiliation string to a stable org ID | ROR (`affiliation=`), then OpenAlex for that org's works |
 | Comprehensive literature search | PubMed + Europe PMC + OpenAlex + Semantic Scholar |
 | Find and read a paper | PubMed (find) + Unpaywall (OA link) + Europe PMC or CORE (full text) |
 | Preprint and its published version | Europe PMC or bioRxiv/medRxiv + Crossref |
@@ -96,7 +104,11 @@ Different databases use different identifier systems. When a lookup fails, a wro
 | Semantic Scholar ID | 40-char hex | `649def34f8be...` | Semantic Scholar |
 | Europe PMC ID | `{source}/{id}` pair | `MED/32117569`, `PPR1283561` | Europe PMC |
 | ORCID | `0000-XXXX-XXXX-XXXX` | `0000-0001-6187-6610` | OpenAlex, Crossref |
-| ISSN | `XXXX-XXXX` | `0028-0836` | Crossref, OpenAlex |
+| ISSN | `XXXX-XXXX` | `0028-0836` | Crossref, OpenAlex, DOAJ |
+| ROR ID | `https://ror.org/` + 9 chars | `https://ror.org/05a0ya142` | ROR, OpenAlex, Crossref |
+| OCI | `{citing}-{cited}` omid suffixes | `06101801781-06180334099` | OpenCitations |
+| Zenodo record | integer, concept ≠ version | `3246411` (version of `3246410`) | Zenodo |
+| BioStudies accession | `S-` / `E-` prefix | `S-BSST12345`, `E-MTAB-1234` | BioStudies |
 
 **Cross-referencing IDs:** Semantic Scholar accepts DOI, PMID, PMCID, and arXiv ID via prefixes (`DOI:10.1038/nature12373`, `PMID:34567890`, `ARXIV:2103.15348`). OpenAlex accepts DOI and PMID via prefixes (`doi:10.1038/...`, `pmid:34567890`). Use the PMC ID Converter to translate between PMID, PMCID, and DOI. When one database has no result for an identifier, converting it and trying another is usually faster than reformulating the query.
 
@@ -116,7 +128,7 @@ Most of these APIs are fully open. A few benefit from a key for higher rate limi
 | Semantic Scholar | `S2_API_KEY` | No (shared pool without, often 429s) | https://www.semanticscholar.org/product/api#api-key-form |
 | OpenAlex | `OPENALEX_API_KEY` | Recommended | https://openalex.org/settings/api |
 
-**Fully open (no key):** Europe PMC (nothing at all — no key, no email), bioRxiv/medRxiv (no documented limits), arXiv (1 req / 3 s), Crossref (add `mailto` for the 2× "polite pool"), Unpaywall (requires a real `email` parameter — placeholders like `test@example.com` are rejected with HTTP 422).
+**Fully open (no key):** Europe PMC (nothing at all — no key, no email), bioRxiv/medRxiv (no documented limits), arXiv (1 req / 3 s), Crossref (add `mailto` for the 2× "polite pool"), Unpaywall (requires a real `email` parameter — placeholders like `test@example.com` are rejected with HTTP 422), OpenCitations, PubTator3 (3 req/s), Zenodo and Figshare *public* record routes, ROR (2000 req / 5 min), BioStudies, DOAJ search.
 
 **Loading keys:** Check the environment first (`$NCBI_API_KEY`, etc.). If a key is absent there and a `.env` exists in the working directory, read **only** the four variables named in the table above — do not load the file wholesale into the environment or into your context, since it routinely holds unrelated secrets that have nothing to do with literature search. If a key is missing, proceed at the lower rate limit and tell the user which key would help and where to get it — don't stall.
 
@@ -141,7 +153,7 @@ curl -s -H "Accept: application/json" -H "x-api-key: $S2_API_KEY" \
 
 - **URL-encode query parameters — including brackets.** DOIs contain `/` (encode as `%2F`), and titles and queries contain spaces, quotes, and parentheses. With `curl`, `--data-urlencode` combined with `--get` is the safe way to pass a search term. Never interpolate an unescaped user string into a URL or shell command. Square brackets need `%5B`/`%5D`: curl reads a literal `[` as a globbing range and **exits 3 before sending the request**, which is how the arXiv date-range syntax silently fetches nothing.
 - **Serialize requests to rate-limited APIs.** NCBI (PubMed, PMC): 3 req/s without key, 10 with. arXiv: **1 request per 3 seconds** — be patient. Crossref: 5 req/s public, 10 with `mailto`.
-- **Parallelize across *different* open APIs only.** OpenAlex, Crossref, Semantic Scholar, Europe PMC, and Unpaywall can run concurrently; keep it to a handful of requests in flight, and never parallelize against the same rate-limited host.
+- **Parallelize across *different* open APIs only.** OpenAlex, Crossref, Semantic Scholar, Europe PMC, Unpaywall, OpenCitations, Zenodo, ROR, BioStudies, and DOAJ can run concurrently; keep it to a handful of requests in flight, and never parallelize against the same rate-limited host. Serialize PubTator3 (3 req/s) and NCBI.
 - **Bound total work.** Start with a count or first page. Don't continue past ~1,000 records or ~50 calls without confirming a short plan with the user — the defaults in `scripts/paginate.py` enforce exactly these bounds. For truly bulk needs, point to the database's snapshot/dump (Unpaywall, OpenAlex, CORE all offer one).
 - **On HTTP 429/503**, wait briefly and retry once. Semantic Scholar without a key hits this often — one retry, then tell the user a key would help.
 
@@ -229,7 +241,7 @@ Default to a readable summary of the fields that matter, not a raw JSON dump. Ra
 
 This skill is designed to grow. Each database is a self-contained file in `references/`. To add one: create `references/<name>.md` following the format of the existing files (base URL, auth, key endpoints with parameter tables, example calls, response shape, pagination/count behavior, rate limits, identifier conventions, and any known hazards), then add a row to the selection guide and the Available Databases tables below.
 
-Run every call you document and record what came back, including the failure modes — the hazard sections in these files are the part that earns the skill its keep. If the new API paginates, add an adapter to `scripts/paginate.py` and a case to `tests/paper-lookup/`.
+Run every call you document and record what came back, including the failure modes — the hazard sections in these files are the part that earns the skill its keep. If the new API paginates *and the walk is easy to get wrong* (bioRxiv-style cursors, silent short pages), add an adapter to `scripts/paginate.py` and a case to `tests/paper-lookup/`. Simple `page`/`size` APIs and dump-all citation lists stay in the reference file.
 
 ## Available Databases
 
@@ -255,12 +267,23 @@ Read the relevant reference file before making any API call.
 | OpenAlex | `references/openalex.md` | 250M+ works, authors, institutions, topics, citation data |
 | Crossref | `references/crossref.md` | 150M+ DOI metadata, journals, funders, references |
 | Semantic Scholar | `references/semantic-scholar.md` | 200M+ papers, citation graphs, AI TLDRs, recommendations |
+| OpenCitations | `references/opencitations.md` | Open citation edges and counts (DOI/PMID/OMID; prefix required) |
+| PubTator3 | `references/pubtator.md` | Text-mined genes, chemicals, diseases, variants, relations |
 
 ### Open Access & Full Text
 | Database | Reference File | What it covers |
 |---|---|---|
 | CORE | `references/core.md` | 37M+ full texts from OA repositories worldwide |
 | Unpaywall | `references/unpaywall.md` | OA status and PDF links for any DOI |
+| DOAJ | `references/doaj.md` | Directory of OA *journals* and their registered articles |
+
+### Repositories & organizations
+| Database | Reference File | What it covers |
+|---|---|---|
+| Zenodo | `references/zenodo.md` | Deposited papers, software, data (concept DOI ≠ version DOI) |
+| Figshare | `references/figshare.md` | Deposited figures, data, media (search is POST, not GET) |
+| BioStudies | `references/biostudies.md` | EBI study packages and links to other archives |
+| ROR | `references/ror.md` | Research organization IDs from names or affiliation strings |
 
 ## Citing Scientific Agent Skills
 

--- a/skills/paper-lookup/references/biostudies.md
+++ b/skills/paper-lookup/references/biostudies.md
@@ -1,0 +1,106 @@
+# BioStudies
+
+EMBL-EBI archive for the data outputs of a life-science study: files hosted
+here, plus links out to ArrayExpress, BioImages, ENA, and other archives.
+Use it when the user wants the *dataset behind a paper*, a BioStudies
+accession (`S-BSST…`, `S-EPMC…`, `S-CMO…`, `E-MTAB…`), or "supplementary
+data at EBI." It is not a paper index.
+
+Find the paper in PubMed / Europe PMC, then come here with an accession or
+a keyword that appears in the study record.
+
+All figures below verified 2026-09-10.
+
+## Base URL
+
+```
+https://www.ebi.ac.uk/biostudies/api/v1
+```
+
+## Authentication
+
+None.
+
+## Rate Limits
+
+No published per-second cap. Serialize. EBI asks for reasonable use.
+
+## Key Endpoints
+
+### 1. Search studies
+
+```
+GET /search?query={text}&page={n}&pageSize={n}
+```
+
+```
+GET /search?query=organoid&pageSize=2
+```
+
+Verified: HTTP 200 with
+
+| Field | Value on this call | Meaning |
+|---|---|---|
+| `page` | 1 | 1-based |
+| `pageSize` | 2 | |
+| `totalHits` | 4195, then 4480 on a later call | **Approximate** |
+| `isTotalHitsExact` | `false` | Do not reconcile as if this were Europe PMC `hitCount` |
+| `nextCursor` | `null` | Page with `page=`, not a cursor |
+| `hits` | 2 study summaries | |
+
+A hit has `accession`, `type` (`study`), `title`, `author`, `files` (count),
+`release_date`, `isPublic`, `content` (a flattened text blob). `author` may
+be an empty string.
+
+`totalHits` moved by hundreds between two calls a few seconds apart, and
+`isTotalHitsExact` stayed false. Report "about N studies" and the page you
+fetched. Do not claim a complete walk against that number.
+
+Page 2 (`page=2&pageSize=2`) returned different accessions and still
+`nextCursor: null`. Keep incrementing `page` until `hits` is empty.
+
+### 2. One study
+
+```
+GET /studies/{accession}
+```
+
+```
+GET /studies/S-CMO2844
+```
+
+Verified: HTTP 200. The body is **not** the search-hit shape:
+
+```json
+{
+  "accno": "S-CMO2844",
+  "type": "submission",
+  "attributes": [{"name": "Title", …}, {"name": "ReleaseDate", …}],
+  "section": { "type": "Study", "accno": "s1", "attributes": […], "subsections": […] }
+}
+```
+
+Title lives in `attributes` (name `Title`), not `title`. Files and links
+are nested under `section.subsections`. Walk that tree; do not expect
+`files: [ …urls ]` at the top level.
+
+A 404 means no such public accession.
+
+## Typical Workflow
+
+1. Search with a paper title, accession, or biological keyword.
+2. Take `accession` from `hits[]`.
+3. `GET /studies/{accession}` for the submission tree and file list.
+4. Cite the accession and the BioStudies URL
+   (`https://www.ebi.ac.uk/biostudies/studies/{accession}`).
+5. If they wanted the paper, go back to PubMed / Europe PMC with the
+   title or a DOI found in the study attributes.
+
+## Failure Modes
+
+| What you did | What happens | What to do |
+|---|---|---|
+| Treated `totalHits` as exact | Count drifts; `isTotalHitsExact` is false | Say "about N"; do not exit-4 reconcile |
+| Expected search fields on `/studies/{acc}` | No `title`, no `files` count | Read `attributes` and `section` |
+| Used BioStudies as PubMed | Studies, not articles | Search literature APIs first |
+| Waited for `nextCursor` | It stays `null` | Use `page` |

--- a/skills/paper-lookup/references/doaj.md
+++ b/skills/paper-lookup/references/doaj.md
@@ -1,0 +1,119 @@
+# DOAJ (Directory of Open Access Journals)
+
+A curated directory of *open-access journals* and the articles those journals
+have registered with DOAJ. Use it to answer "is this journal in DOAJ?" or
+"articles in DOAJ-listed journals matching X." It is not a general literature
+index and it is not Unpaywall.
+
+Nature is not in DOAJ. A paper can be open access (hybrid, bronze, green)
+without its journal being listed here. For "is there a free PDF of this DOI?"
+use Unpaywall. For the yes/no "is this journal in DOAJ?" when you are already
+on OpenAlex, `GET /sources/issn:{issn}` returns `is_in_doaj` (PLoS ONE
+`1932-6203` is `true`; Nature `0028-0836` is `false`) — stay there. Come
+to DOAJ when you need APC, licence, or `oa_start`. For "papers on CRISPR"
+use PubMed / OpenAlex, then optionally restrict to DOAJ journals.
+
+All figures below verified 2026-09-10 against API **v4**.
+
+## Base URL
+
+```
+https://doaj.org/api
+```
+
+Docs (live): https://doaj.org/api/docs
+
+Search URLs you write as `/api/search/...` are served as v4; `next` links
+in the JSON point at `/api/v4/search/...`. Either form works.
+
+## Authentication
+
+Public search needs no key. API keys are for publisher submitters. Do not
+ask the user for a DOAJ key to look up a journal.
+
+## Rate Limits
+
+No published per-second cap. Be polite. Prefer a journal ISSN lookup over
+paging through tens of thousands of article hits.
+
+## Query syntax
+
+The path segment *is* the query (Elasticsearch query string). Slash in a DOI
+is escaped for you.
+
+| Goal | Query |
+|---|---|
+| Article title words | `bibjson.title:CRISPR` |
+| DOI | `doi:10.3389/fpsyg.2013.00479` |
+| Journal ISSN | `issn:1932-6203` |
+| Exact journal title | `bibjson.title.exact:"PLoS ONE"` |
+| Short names | `title:`, `issn:`, `publisher:`, `license:` (journals) |
+
+`.exact` works on full field names, **not** on the short aliases.
+
+## Key Endpoints
+
+### 1. Search articles
+
+```
+GET /search/articles/{query}?page=1&pageSize=10
+```
+
+```
+GET /search/articles/bibjson.title:CRISPR?pageSize=2
+```
+
+Verified: `total` 7777, `page` 1, `pageSize` 2, `results` length 2.
+`next` was
+`https://doaj.org/api/v4/search/articles/bibjson.title:CRISPR?page=2&pageSize=2`.
+Follow `next` (or increment `page`) rather than guessing a last page —
+`last` pointed at page 3889.
+
+Each result has `id`, `created_date`, `last_updated`, `bibjson`. Identifiers
+are a **list**:
+
+```json
+"identifier": [
+  {"id": "10.3390/v14102045", "type": "doi"},
+  {"id": "1999-4915", "type": "eissn"}
+]
+```
+
+Pick `type == "doi"`. Do not take `identifier[0]` blindly (it may be an ISSN).
+
+### 2. Search journals
+
+```
+GET /search/journals/{query}?page=1&pageSize=10
+```
+
+Verified:
+
+| Query | `total` | Notes |
+|---|---|---|
+| `issn:0028-0836` (Nature) | 0 | Subscription journal. Empty is the answer. |
+| `issn:1932-6203` (PLoS ONE) | 1 | `bibjson.title` `PLoS ONE`, `oa_start` 2006, `apc.has_apc` true, max 2477 USD |
+
+HTTP 200 + `total: 0` + `results: []` means "not a DOAJ journal," not an
+outage. Unpaywall may still find a green or hybrid copy of a Nature paper.
+
+Journal `bibjson` includes title, ISSNs, publisher, license, APC, and
+`oa_start`. That is the record to quote when someone asks "is this journal
+OA in DOAJ?"
+
+## Typical Workflow
+
+1. Have an ISSN or journal title → `/search/journals/issn:{issn}`.
+2. Have a DOI you believe is in a DOAJ journal → `/search/articles/doi:{doi}`.
+3. If journals search is empty, say so and check Unpaywall for the article.
+4. Do not page `bibjson.title:CRISPR` as a substitute for PubMed.
+
+## Failure Modes
+
+| What you did | What happens | What to do |
+|---|---|---|
+| ISSN of a non-DOAJ journal | 200, `total: 0` | Report "not in DOAJ"; try Unpaywall |
+| Took `identifier[0]` as the DOI | You may get an eISSN | Filter `type == "doi"` |
+| Used DOAJ as Unpaywall | Misses hybrid/green OA | Article-level OA is Unpaywall |
+| Second host just for yes/no | Extra call | OpenAlex `sources.is_in_doaj` if you are already there |
+| Used short field + `.exact` | Query does not mean what you think | Use `bibjson.title.exact` |

--- a/skills/paper-lookup/references/figshare.md
+++ b/skills/paper-lookup/references/figshare.md
@@ -1,0 +1,90 @@
+# Figshare
+
+A general research repository (figures, datasets, posters, papers, media).
+Use it when the user names Figshare or a `figshare.com` DOI, or wants files
+deposited there. It is not a journal index. For OA journal PDFs use Unpaywall;
+for EBI-hosted study packages use BioStudies; for CERN-style software dumps
+prefer Zenodo.
+
+All figures below verified 2026-09-10.
+
+## Base URL
+
+```
+https://api.figshare.com/v2
+```
+
+Docs: https://docs.figshare.com/v2/
+
+## Authentication
+
+Public article metadata does not need a token. Private records, uploads, and
+account endpoints do (`Authorization: token ACCESS_TOKEN`). This skill only
+uses the public routes.
+
+## Rate Limits
+
+Documented on the API site; stay well under interactive use. Serialize.
+
+## Key Endpoints
+
+### 1. Search — POST, not GET
+
+```
+POST /v2/articles/search
+Content-Type: application/json
+
+{"search_for": "CRISPR", "page": 1, "page_size": 10}
+```
+
+Verified: HTTP 200, a **bare JSON array** (no `total`, no `hits` wrapper).
+First hit was a CRISPR supplementary dataset (`defined_type_name: dataset`).
+
+There is no count in the body and no useful `Link`/`X-Count` header on this
+call. Walk `page` until a page comes back shorter than `page_size` or empty.
+Do not invent a total.
+
+**GET is not a search.** This is the trap that produces a confident wrong
+paper:
+
+```
+GET /v2/articles?search_for=CRISPR&page_size=1
+```
+
+Verified: HTTP 200, one article, title *Social capital in the workplace…*,
+DOI `10.1016/j.labeco.2007.07.006`. The query string is ignored; you are
+listing articles. If the user asked for CRISPR and you used GET, you will
+report the wrong object with a 200.
+
+### 2. One article
+
+```
+GET /v2/articles/{id}
+```
+
+```
+GET /v2/articles/12345
+```
+
+Verified: HTTP 200 with `id`, `title`, `doi`, `defined_type_name`, `url`,
+authors, files, license. Use this after search, or when the user already
+has a Figshare id.
+
+Files, when public, appear on the article object. A 404 is either no such
+id or a record you are not allowed to read (the API uses 404 for both).
+
+## Typical Workflow
+
+1. `POST /articles/search` with a JSON body.
+2. Read `id`, `title`, `doi`, `defined_type_name` from each element.
+3. `GET /articles/{id}` only if you need files or a fuller record.
+4. If they wanted papers *about* a topic, go to OpenAlex / PubMed. Figshare
+   search is repository search.
+
+## Failure Modes
+
+| What you did | What happens | What to do |
+|---|---|---|
+| `GET /articles?search_for=…` | HTTP 200, unrelated latest-ish articles | POST `/articles/search` |
+| Expected `{hits: …, total: N}` | A raw array | Treat `[]` as empty; no total to reconcile |
+| Reported a Figshare hit as a journal article | `defined_type_name` may be dataset, figure, media | Read and report the type |

--- a/skills/paper-lookup/references/opencitations.md
+++ b/skills/paper-lookup/references/opencitations.md
@@ -1,0 +1,138 @@
+# OpenCitations
+
+Open citation data (who cites whom) as open lists of citing/cited PIDs. Use it when you
+need an openly licensed citation edge, a count you can cite, or an Open Citation
+Identifier (OCI). It is not a paper search and it does not return titles on the Index
+endpoints.
+
+For a literature search use PubMed, OpenAlex, or Semantic Scholar. For a citation
+*graph with titles and abstracts*, start with Semantic Scholar or OpenAlex and treat
+OpenCitations as the open-data check. Europe PMC `/citations` is the biomedical
+alternative when you already have a `{source}/{id}` pair.
+
+All figures below verified 2026-09-10.
+
+## Base URLs
+
+```
+https://api.opencitations.net/index/v2    # citation edges and counts
+https://api.opencitations.net/meta/v1     # bibliographic metadata for a PID
+```
+
+Index v2 is current (v2.2.0, 2025-04-15). Meta lives at **v1** — `meta/v2/...`
+is HTTP 404.
+
+## Authentication
+
+Optional. Public calls work without a token. For heavier use, request an access
+token from OpenCitations and send `Authorization: <token>`. Do not add a new
+`.env` key for this; proceed without one.
+
+## Rate Limits
+
+No published per-second cap. Serialize requests. Call `/citation-count` before
+`/citations` — the list endpoint returns **every** incoming citation in one
+body, with no page parameter.
+
+## Identifier prefix (required)
+
+Index v2 IDs must be `doi:`, `pmid:`, or `omid:`. A bare DOI is HTTP 400:
+
+```
+GET /index/v2/citation-count/10.1038/nature12373
+  -> 400  the value '10.1038/nature12373' is not valid for parameter 'id'
+          Example: /index/v2/citation-count/doi:10.1108/jd-12-2013-0166
+
+GET /index/v2/citation-count/doi:10.1038/nature12373
+  -> 200  [{"count": "1806"}]
+```
+
+## Key Endpoints
+
+### 1. Incoming citation count
+
+```
+GET /index/v2/citation-count/{id}
+```
+
+Always a one-element JSON array. `count` is a **string**, not an integer.
+
+| Query | HTTP | Body |
+|---|---|---|
+| `doi:10.1038/nature12373` | 200 | `[{"count": "1806"}]` |
+| `pmid:23803767` | 200 | `[{"count": "94"}]` |
+| `doi:10.9999/not-a-real-doi` | 200 | `[{"count": "0"}]` |
+
+A missing work is HTTP 200 with `"0"`, not 404. Do not treat 200 as "this DOI
+is in the index."
+
+### 2. Outgoing reference count
+
+```
+GET /index/v2/reference-count/{id}
+```
+
+Same shape as citation-count.
+
+### 3. Incoming citations / outgoing references
+
+```
+GET /index/v2/citations/{id}
+GET /index/v2/references/{id}
+```
+
+Each item:
+
+| Field | Meaning |
+|---|---|
+| `oci` | Open Citation Identifier (`citingOmidsuffix-citedOmidsuffix`) |
+| `citing` / `cited` | Space-separated PIDs, each prefixed (`doi:`, `pmid:`, `omid:`, `openalex:`) |
+| `creation` | ISO date of the citing work |
+| `timespan` | XSD duration (`P6Y0M1D`) between cited and citing publication |
+| `journal_sc` / `author_sc` | `"yes"` / `"no"` self-citation flags |
+
+Verified on `doi:10.1038/nature12373` `/references`: 30 rows. First `citing` is
+`omid:br/06120344846 doi:10.1038/nature12373 openalex:W2159974629 pmid:23903748`.
+Parse the `doi:` token out; do not take the whole string as one DOI.
+
+Verified on `doi:10.1186/1756-8722-6-59` `/citations`: 217 rows in one response.
+For `nature12373` the count is 1806 — do not pull that list unless the user
+asked for the full set.
+
+### 4. One citation by OCI
+
+```
+GET /index/v2/citation/{oci}
+```
+
+`oci` is the two-number form without an `oci:` prefix.
+
+### 5. Metadata (titles, authors)
+
+```
+GET /meta/v1/metadata/{id}
+```
+
+Same `doi:` / `pmid:` / `omid:` prefix. Returns `id` (space-separated PIDs),
+`title`, `author` (semicolon-separated, may include ORCID + OMID). Use this
+when you have an edge from Index and need a human-readable label.
+
+## Typical Workflow
+
+1. You have a DOI or PMID.
+2. `citation-count` first. If `"0"`, say OpenCitations has no incoming citations
+   — not that the paper is uncited everywhere.
+3. For a short list, `/references` or `/citations`. Extract the `doi:` token
+   from each `citing`/`cited` string.
+4. Resolve titles with Meta, Crossref, or Semantic Scholar. Do not invent them
+   from the OCI.
+
+## Failure Modes
+
+| What you did | What happens | What to do |
+|---|---|---|
+| Bare DOI, no `doi:` prefix | HTTP 400 | Prefix the scheme |
+| Unknown DOI | HTTP 200, `count: "0"` | Report a gap; try Semantic Scholar |
+| Parsed `citing` as one DOI | You store `omid:br/… doi:10.… pmid:…` | Split on spaces; keep the `doi:` value |
+| `/citations` on a highly cited work | Multi-megabyte JSON, no pagination | Count first; bound the pull |
+| `meta/v2/...` | HTTP 404 HTML | Use `meta/v1` |

--- a/skills/paper-lookup/references/pubtator.md
+++ b/skills/paper-lookup/references/pubtator.md
@@ -1,0 +1,151 @@
+# PubTator3
+
+NCBI text-mined annotations on PubMed abstracts (and some PMC full text): genes,
+diseases, chemicals, species, variants, and cell lines, plus typed relations.
+Use it when the user wants *entities in a paper* or papers that mention a
+normalized entity (`@CHEMICAL_remdesivir`), not when they want a citation list.
+
+Europe PMC `/textMinedTerms` is a thinner per-article alternative. PubMed search
+does not normalize "remdesivir" to a concept ID. PubTator3 APIs are **not** the
+old PubTator / `CBBresearch` endpoints.
+
+All figures below verified 2026-09-10.
+
+## Base URL
+
+```
+https://www.ncbi.nlm.nih.gov/research/pubtator3-api
+```
+
+Docs: https://www.ncbi.nlm.nih.gov/research/pubtator3/api
+
+## Authentication
+
+None.
+
+## Rate Limits
+
+No more than **3 requests per second**. Serialize. For bulk annotation dumps use
+the FTP site (`https://ftp.ncbi.nlm.nih.gov/pub/lu/PubTator3/`) rather than the
+API.
+
+## Key Endpoints
+
+### 1. Resolve a mention to an entity ID
+
+```
+GET /entity/autocomplete/?query={text}&concept={type}&limit={n}
+```
+
+`concept` is optional (`chemical`, `disease`, `gene`, `species`, `variant`,
+`cellline`).
+
+```
+GET /entity/autocomplete/?query=remdesivir&limit=3
+```
+
+Returns a JSON array. First hit (verified):
+
+```json
+{
+  "_id": "@CHEMICAL_remdesivir",
+  "biotype": "chemical",
+  "db_id": "C000606551",
+  "db": "ncbi_mesh",
+  "name": "remdesivir"
+}
+```
+
+Search with `_id` (`@CHEMICAL_remdesivir`), not the display name. Nearby
+synonyms (`@CHEMICAL_GS_441524_triphosphate`) are different entities.
+
+### 2. Search papers by text, entity, or relation
+
+```
+GET /search/?text={query}&page={n}
+```
+
+`text` may be free text, an `@TYPE_name` entity ID, a boolean combination, or a
+relation:
+
+```
+@CHEMICAL_Doxorubicin AND @DISEASE_Neoplasms
+relations:ANY|@CHEMICAL_Doxorubicin|@DISEASE_Neoplasms
+relations:ANY|@CHEMICAL_Doxorubicin|DISEASE
+```
+
+```
+GET /search/?text=@CHEMICAL_remdesivir
+```
+
+Verified: `count` 23295, `page_size` 10, `current` 1, `total_pages` 2330,
+`results` length 10. First result `pmid` is an **integer** (`37711410`); `_id`
+is a string. Page with `page` (1-based). There is no cursor.
+
+Do not use this as a general PubMed replacement. Rank is entity-centric.
+
+### 3. Export annotations for PMIDs
+
+```
+GET /publications/export/{format}?pmids={id,id}&full={true|false}
+```
+
+`format` is `pubtator`, `biocxml`, or `biocjson`. `full=true` (PMC full text)
+works only for `biocxml` / `biocjson`.
+
+```
+GET /publications/export/biocjson?pmids=29355051
+```
+
+The JSON is **not** a bare BioC document. It is:
+
+```json
+{ "PubTator3": [ { "_id": "29355051|None", "id": "29355051", "passages": [...], "relations": [...] } ] }
+```
+
+Verified on PMID 29355051: one document, two passages, first passage has 5
+annotations. An annotation looks like:
+
+```json
+{
+  "infons": {
+    "type": "Species",
+    "database": "ncbi_taxonomy",
+    "normalized_id": 112863,
+    "biotype": "species"
+  },
+  "text": "Lycium barbarum",
+  "locations": [{"offset": 14, "length": 15}]
+}
+```
+
+Read `PubTator3[0].passages[].annotations`. A 200 with `"PubTator3": []` is
+"no documents," not a transport success you can ignore.
+
+### 4. Related entities
+
+```
+GET /relations?e1={entityId}&type={relation}&e2={entity_type}
+```
+
+Relation types include `treat`, `cause`, `interact`, `associate`,
+`positive_correlate`, `negative_correlate`, `prevent`, `inhibit`, `stimulate`,
+`drug_interact`. `e1` must be an autocomplete `_id`.
+
+## Typical Workflow
+
+1. Autocomplete the user's string → `@CHEMICAL_…` / `@DISEASE_…`.
+2. Search with that ID (and a relation if they asked "what does X treat?").
+3. Export `biocjson` for the PMIDs you will report, and list the annotations.
+4. For the paper itself (abstract, OA PDF), go to PubMed / Europe PMC /
+   Unpaywall. PubTator is not a full-text store.
+
+## Failure Modes
+
+| What you did | What happens | What to do |
+|---|---|---|
+| Parsed export JSON as BioC root | No `passages` at the top level | Descend into `PubTator3` |
+| Searched `remdesivir` and treated hits as exact-chemical papers | Keyword search, not the concept | Autocomplete, then search `@CHEMICAL_remdesivir` |
+| Called the old `pubtator-api` or `CBBresearch` URL | May still 200, but the contract changed | Use `pubtator3-api` |
+| `full=true` with `format=pubtator` | No full text | Use `biocjson` or `biocxml` |
+| Parallel fan-out | Easy to exceed 3 req/s | Serialize |

--- a/skills/paper-lookup/references/ror.md
+++ b/skills/paper-lookup/references/ror.md
@@ -1,0 +1,121 @@
+# ROR (Research Organization Registry)
+
+Open registry of research organizations. Use it to turn an affiliation string
+into a ROR ID (`https://ror.org/05a0ya142`) or to look up one org. It is not
+a paper database. OpenAlex and Crossref already *carry* ROR IDs on works;
+this API is how you mint or check the ID itself.
+
+All figures below verified 2026-09-10. Use the **v2** routes.
+
+## Base URL
+
+```
+https://api.ror.org/v2
+```
+
+Docs: https://ror.readme.io/docs/rest-api
+
+## Authentication
+
+None. Heartbeat: `GET https://api.ror.org/heartbeat` → `OK`.
+
+## Rate Limits
+
+2000 requests / 5 minutes / IP. Traffic spikes around midnight UTC. For bulk
+matching, run the API locally (Docker) rather than hammering the public host.
+
+## Identifier
+
+A ROR ID is `https://ror.org/` plus nine characters (`0` + 6 alphanumeric +
+2 check-ish chars), e.g. `https://ror.org/05a0ya142`. The path
+`/v2/organizations/05a0ya142` accepts the suffix alone.
+
+## Key Endpoints
+
+### 1. Keyword / identifier search
+
+```
+GET /v2/organizations?query={text}
+```
+
+Searches **only** `names` and `external_ids` (GRID, ISNI, Wikidata, Crossref
+Funder ID). It does not search addresses, websites, or relationships.
+
+Unquoted common words explode. Verified:
+
+| `query` | `number_of_results` | First hit |
+|---|---|---|
+| `Broad Institute` | 13016 | Broad Institute (lucky, not guaranteed) |
+| `"Broad Institute"` | 3 | Broad Institute |
+
+Never take `items[0]` as the match without reading `names` and `status`.
+Quote the string (`%22…%22`) when the user gave a proper name.
+
+Default page is 20 active records. Filter and page per
+https://ror.readme.io/docs/api-filtering and
+https://ror.readme.io/docs/api-paging. Pass `all_status=true` if you need
+inactive / withdrawn orgs in a list.
+
+### 2. Affiliation matcher (unstructured strings)
+
+```
+GET /v2/organizations?affiliation={raw affiliation}
+```
+
+Best for "Broad Institute of MIT and Harvard, Cambridge, MA" dumped from a
+PDF. As of 2026-05-26 this parameter defaults to the **single search**
+strategy.
+
+The JSON is **not** the same as `?query=`. Each item is a match wrapper:
+
+```json
+{
+  "substring": "Broad Institute of MIT and Harvard, Cambridge, MA",
+  "score": 1.0,
+  "matching_type": "SINGLE SEARCH",
+  "chosen": true,
+  "organization": { "id": "https://ror.org/05a0ya142", "names": […], "status": "active" }
+}
+```
+
+Read `items[].organization` and `chosen`. `items[0].id` is absent — that is
+how a naive parse reports "no ROR ID" after a successful match.
+
+Verified: 10 items, first `chosen` true, organization is Broad Institute.
+
+### 3. One organization
+
+```
+GET /v2/organizations/{ror_id_or_suffix}
+```
+
+```
+GET /v2/organizations/05a0ya142
+```
+
+Always returns the record, including `inactive` / `withdrawn`. Lists hide
+those statuses by default; a single-id GET does not. Check `status` before
+writing the ID into metadata.
+
+v2 records have `names[]` (with types: ror_display, alias, acronym, label),
+not a top-level `name`. `/organizations/{id}` without `/v2` currently still
+returns the v2 shape; call `/v2/` so a future default change does not flip
+the schema under you.
+
+## Typical Workflow
+
+1. Proper name or GRID/ISNI → `?query="…"` and inspect the shortlist.
+2. Messy affiliation line → `?affiliation=` and keep rows with
+   `chosen: true` (or a high `score` you are willing to stand behind).
+3. Known ROR ID → GET the record and confirm `status: active`.
+4. Then, if the user wanted papers from that org, search OpenAlex /
+   Crossref with the ROR ID. Do not search ROR for papers.
+
+## Failure Modes
+
+| What you did | What happens | What to do |
+|---|---|---|
+| Unquoted `University` / `Institute` query | Thousands of hits | Quote the name; do not auto-pick |
+| Read `items[0].id` on an affiliation response | `null` | Use `items[0].organization.id` |
+| Wrote an inactive ROR from a single-id GET | Record exists, `status` is not `active` | Read `status` |
+| Used v1 field `name` | Missing | Use `names[].value` |

--- a/skills/paper-lookup/references/zenodo.md
+++ b/skills/paper-lookup/references/zenodo.md
@@ -1,0 +1,109 @@
+# Zenodo
+
+CERN's general research repository: papers, preprints, software, datasets,
+presentations, and posters, each with a DataCite DOI (`10.5281/zenodo.…`).
+Use it when the user wants a deposited record or file, not a journal article
+index. For journal OA PDFs use Unpaywall. For biology datasets that live at
+EBI, try BioStudies first.
+
+All figures below verified 2026-09-10.
+
+## Base URL
+
+```
+https://zenodo.org/api
+```
+
+Docs: https://developers.zenodo.org/
+
+## Authentication
+
+**Published records are public.** `GET /api/records` works with no token.
+
+Deposit / publish (`/api/deposit/depositions`) requires a personal access
+token and is out of scope for this skill. Without a token that path returns
+HTTP **403** `Permission denied.` (not always 401). Do not start a deposit
+flow from a literature lookup.
+
+## Rate Limits
+
+No published per-second cap. Be polite; serialize long walks.
+
+## Key Endpoints
+
+### 1. Search published records
+
+```
+GET /api/records?q={elasticsearch}&type={type}&size={n}&page={n}
+```
+
+`q` is Elasticsearch syntax. `type` filters the Invenio resource type
+(`publication`, `software`, `dataset`, `image`, `poster`, `presentation`,
+`video`, `other`). Default search mixes all of them.
+
+```
+GET /api/records?q=CRISPR+organoid&size=2
+```
+
+Verified: HTTP 200, `hits.total` 3499, two hits. First hit was an SSRN
+*publication*, not a dataset. Always read `metadata.resource_type`.
+
+```
+GET /api/records?q=scanpy&type=software&size=2
+```
+
+Verified: `hits.total` 40; both hits `resource_type.type` is `software`.
+
+Response shape:
+
+```json
+{
+  "hits": { "total": 3499, "hits": [ { "id": …, "doi": …, "metadata": {…}, "files": […], "links": {…} } ] },
+  "links": { "self": "…", "next": "…" }
+}
+```
+
+Page with `page` (1-based) and `size`. Follow `links.next` when present.
+
+### 2. One record by id or DOI
+
+```
+GET /api/records/{id}
+GET /api/records?q=doi:10.5281/zenodo.{id}
+```
+
+**Follow redirects.** A concept (parent) record id 302s to the latest version:
+
+```
+GET /api/records/3246410
+  -> 302  Location: /api/records/3246411
+GET /api/records/3246411   (after curl -L)
+  -> 200  id=3246411
+          doi=10.5281/zenodo.3246411          # this version
+          conceptdoi=10.5281/zenodo.3246410   # all versions
+          conceptrecid=3246410
+```
+
+`curl` without `-L` returns HTML "Redirecting…" and JSON parse fails. Use
+`-L` and then report both DOIs: the version DOI is the file you fetched;
+the concept DOI is the stable cite-all-versions id.
+
+Files (when present) live on `files[]` with a download URL under `links`.
+A record can be published and still have no downloadable file.
+
+## Typical Workflow
+
+1. Search with `q` and a `type` if the user said software, data, or poster.
+2. Take `id` / `doi` from `hits.hits[]`.
+3. `GET /api/records/{id}` with `-L` for files and the concept/version pair.
+4. If they wanted a journal PDF, stop and use Unpaywall on the paper DOI
+   instead of scraping a Zenodo landing page.
+
+## Failure Modes
+
+| What you did | What happens | What to do |
+|---|---|---|
+| Search without `type` | Software, data, and papers mixed | Filter `type=` or report the resource type |
+| `GET /records/{conceptrecid}` without `-L` | HTTP 302 + HTML | Follow redirects; record both DOIs |
+| Treated deposit docs as required auth | You ask the user for a token to *search* | Search is public |
+| Cited `10.5281/zenodo.{concept}` as the file you downloaded | Concept DOI is all versions | Use the version DOI in provenance |


### PR DESCRIPTION
## Summary
- Extend `paper-lookup` (v2.0 → v2.1) from 11 to 18 APIs with reference files for OpenCitations, PubTator3, Zenodo, Figshare, ROR, BioStudies, and DOAJ. The original 11 stay the literature core; these seven answer citation-edge, entity, repository, affiliation, and journal-OA questions.
- No new scripts. Paging is ordinary `page`/`size` (or dump-all on OpenCitations), so `paginate.py` is unchanged.
- Documented live HTTP-200 traps: Figshare GET ignores `search_for`, OpenCitations missing DOIs return `count: "0"`, Zenodo concept ids 302 to the version record, ROR unquoted names explode, BioStudies `totalHits` is inexact, Nature is not in DOAJ.

@TKassis — requesting your review. Companion to #262 (ontology-term-resolution), separate branch.

## Test plan
- [x] `uv run skills-ref validate skills/paper-lookup`
- [x] `uv run --with pytest python -m pytest tests/paper-lookup tests/_meta -q`
- [x] Live smoke (2026-09-10): OpenCitations prefixed/bare/missing DOI; Figshare GET vs POST; Zenodo redirect; ROR quoted vs unquoted; BioStudies `isTotalHitsExact`; DOAJ Nature vs PLOS ONE; PubTator3 `PubTator3` wrapper
- [ ] Reviewer: confirm these belong in `paper-lookup` rather than `database-lookup`, and that DOAJ stays journal-level (Unpaywall still owns article OA)


Made with [Cursor](https://cursor.com)