### PR TITLE
Add RegulomeDB and live VEP/CADD traps to database-lookup

### DIFF
--- a/skills/database-lookup/SKILL.md
+++ b/skills/database-lookup/SKILL.md
@@ -4,13 +4,13 @@ description: Query documented public database APIs with explicit endpoints, filt
 allowed-tools: Read Bash
 license: MIT
 metadata:
-  version: "1.5"
+  version: "1.6"
   skill-author: "K-Dense Inc."
 ---
 
 # Database Lookup
 
-This skill catalogs 78 public databases with documented API access patterns. Your job is to turn the user's intent into a reproducible retrieval: select the authoritative database(s), make bounded and rate-limited API calls, verify counts when completeness matters, and return results with enough provenance that another agent or human can repeat the lookup.
+This skill catalogs 80 public databases with documented API access patterns. Your job is to turn the user's intent into a reproducible retrieval: select the authoritative database(s), make bounded and rate-limited API calls, verify counts when completeness matters, and return results with enough provenance that another agent or human can repeat the lookup.
 
 For complex biomedical retrievals, assume small filtering differences can change downstream conclusions. Prefer deterministic APIs, explicit identifiers, exhaustive pagination, and auditable logs over broad searching or plausible summaries.
 
@@ -82,7 +82,7 @@ When a database doesn't recognize an identifier, convert it using these workflow
 
 **Compounds**: Name → **PubChem** `/compound/name/{name}/cids/JSON` → get CID → convert to ChEMBL ID via **UniChem** or **ChEMBL** molecule search. If name lookup fails, try SMILES, InChIKey, or CAS number.
 
-**Variants**: rsID (e.g. "rs334") works directly in **dbSNP**, **ClinVar**, **GWAS Catalog**, **gnomAD**. For genomic coordinates, use **Ensembl** VEP to get consequence annotations and linked rsIDs.
+**Variants**: rsID (e.g. "rs334") works directly in **dbSNP**, **ClinVar**, **GWAS Catalog**, **gnomAD**. For genomic coordinates, use **Ensembl** VEP for consequence annotations (`CADD=1` for live `cadd_phred`) and **RegulomeDB** for noncoding regulatory rank. MyVariant is a cached bundle — confirm any score at those live sources.
 
 **Diseases**: Name → **Open Targets** or **Monarch** search → get EFO or MONDO ID → use in downstream queries.
 
@@ -314,7 +314,7 @@ Read the relevant reference file before making any API call.
 | BRENDA | `references/brenda.md` | Enzyme kinetics, catalysis (SOAP) |
 | UniProt | `references/uniprot.md` | Protein sequences, function |
 | STRING | `references/string.md` | Protein-protein interactions |
-| Ensembl | `references/ensembl.md` | Genomes, variants, sequences |
+| Ensembl | `references/ensembl.md` | Genomes, variants, sequences, VEP (+ CADD) |
 | NCBI Gene | `references/ncbi-gene.md` | Gene information, links |
 | NCBI Protein | `references/ncbi-protein.md` | Protein sequences, records |
 | NCBI Taxonomy | `references/ncbi-taxonomy.md` | Taxonomic classification |
@@ -333,6 +333,8 @@ Read the relevant reference file before making any API call.
 | UCSC Genome Browser | `references/ucsc-genome.md` | Genome annotations, tracks |
 | ENCODE | `references/encode.md` | DNA elements, ChIP-seq, ATAC-seq |
 | JASPAR | `references/jaspar.md` | TF binding profiles/motifs |
+| RegulomeDB | `references/regulomedb.md` | Noncoding SNV regulatory rank (0-based window) |
+| MyVariant.info | `references/myvariant.md` | Cached variant annotation bundle (hg19 ids) |
 | Human Protein Atlas | `references/human-protein-atlas.md` | Protein expression across tissues |
 | Human Cell Atlas | `references/hca.md` | Single-cell atlas data |
 | LINCS L1000 | `references/lincs-l1000.md` | Gene expression signatures (CMap) |

--- a/skills/database-lookup/references/database_selection_guide.md
+++ b/skills/database-lookup/references/database_selection_guide.md
@@ -79,6 +79,9 @@ Match the user's intent to the right database(s). Many queries benefit from hitt
 | Protein sequences (NCBI) | NCBI Protein | UniProt |
 | Taxonomic classification | NCBI Taxonomy | — |
 | SNP/variant data (dbSNP) | dbSNP | ClinVar, gnomAD |
+| Variant consequence / CADD PHRED | Ensembl VEP (`CADD=1`) | dbSNP |
+| Noncoding regulatory evidence | RegulomeDB | ENCODE, JASPAR |
+| Cached variant annotation bundle | MyVariant.info | Ensembl VEP (live scores) |
 | Population variant frequencies | gnomAD | dbSNP |
 | Sequencing run metadata | SRA | ENA, GEO |
 | Nucleotide sequences (European archive) | ENA | SRA, NCBI Gene |

--- a/skills/database-lookup/references/ensembl.md
+++ b/skills/database-lookup/references/ensembl.md
@@ -191,8 +191,13 @@ GET /vep/{species}/hgvs/{hgvs_notation}?content-type=application/json
 **Example:**
 ```
 https://rest.ensembl.org/vep/homo_sapiens/hgvs/ENST00000269305.9:c.817C>T?content-type=application/json
-https://rest.ensembl.org/vep/homo_sapiens/hgvs/17:g.7674220G>A?content-type=application/json
+https://rest.ensembl.org/vep/homo_sapiens/hgvs/17:g.7675088C>G?CADD=1&content-type=application/json
 ```
+
+`CADD=1` is how you get `cadd_phred`. Without it the field is absent.
+Verified 2026-09-11: `17:g.7675088C>G` is `missense_variant` / TP53 /
+`cadd_phred` **29.4**. The older worked example `17:g.7674220G>A` is
+HTTP 400 — the reference at 7674220 is `C`, not `G`.
 
 **By genomic region:**
 ```
@@ -201,8 +206,13 @@ GET /vep/{species}/region/{region}/{allele}?content-type=application/json
 
 **Example:**
 ```
-https://rest.ensembl.org/vep/homo_sapiens/region/17:7674220-7674220:1/A?content-type=application/json
+https://rest.ensembl.org/vep/homo_sapiens/region/17:7675088-7675088:1/G?CADD=1&content-type=application/json
 ```
+
+The path carries the **alt** only. VEP reads the reference from the
+assembly. `17:7675088-7675088:1/G` returns `allele_string: C/G` even if
+you thought the ref was `A`. Compare `allele_string` to the alleles you
+meant, or use `/hgvs/` (which 400s on a wrong ref).
 
 **By rsID:**
 ```
@@ -211,20 +221,25 @@ GET /vep/{species}/id/{rsid}?content-type=application/json
 
 **Example:**
 ```
+https://rest.ensembl.org/vep/homo_sapiens/id/rs28934578?CADD=1&content-type=application/json
 https://rest.ensembl.org/vep/homo_sapiens/id/rs699?content-type=application/json
 ```
+
+`rs28934578` is multi-allelic (`C/A/G/T`). `most_severe_consequence` is
+one label across **every** transcript (117 here, vs 39 on the single-alt
+region call). Do not quote it as the consequence of one allele.
 
 **VEP Response:**
 ```json
 [
   {
-    "input": "17:g.7674220G>A",
+    "input": "17:g.7675088C>G",
     "assembly_name": "GRCh38",
     "seq_region_name": "17",
-    "start": 7674220,
-    "end": 7674220,
+    "start": 7675088,
+    "end": 7675088,
     "strand": 1,
-    "allele_string": "G/A",
+    "allele_string": "C/G",
     "most_severe_consequence": "missense_variant",
     "transcript_consequences": [
       {
@@ -234,14 +249,12 @@ https://rest.ensembl.org/vep/homo_sapiens/id/rs699?content-type=application/json
         "biotype": "protein_coding",
         "consequence_terms": ["missense_variant"],
         "impact": "MODERATE",
-        "amino_acids": "R/H",
-        "codons": "cGc/cAc",
-        "protein_start": 248,
-        "polyphen_prediction": "probably_damaging",
-        "polyphen_score": 1.0,
+        "amino_acids": "R/P",
+        "codons": "cGc/cCc",
+        "protein_start": 175,
         "sift_prediction": "deleterious",
         "sift_score": 0.0,
-        "cadd_phred": 35.0
+        "cadd_phred": 29.4
       }
     ],
     "colocated_variants": [
@@ -260,8 +273,12 @@ https://rest.ensembl.org/vep/homo_sapiens/id/rs699?content-type=application/json
 POST /vep/homo_sapiens/region
 Content-Type: application/json
 
-{ "variants": ["17 7674220 7674220 G/A 1", "7 140753336 140753336 A/T 1"] }
+{ "variants": ["17 7675088 7675088 C/G 1", "7 140753336 140753336 A/T 1"] }
 ```
+
+Add `CADD=1` as a query parameter on GET or in the POST body when you
+need live CADD v1.7. That value matches a direct CADD lookup; MyVariant's
+cached `cadd.phred` for this variant was 35 the same day (`myvariant.md`).
 
 ---
 

--- a/skills/database-lookup/references/myvariant.md
+++ b/skills/database-lookup/references/myvariant.md
@@ -1,0 +1,54 @@
+# MyVariant.info
+
+A cached bundle of annotations (CADD, dbNSFP, ClinVar snippets, dbSNP)
+keyed by **hg19** genomic HGVS. Use it as a "what else is already stored?"
+pass, then confirm any score you will write at the live source — Ensembl
+VEP with `CADD=1` (`ensembl.md` §6), not this cache.
+
+Docs: https://docs.myvariant.info/en/latest/
+All figures verified 2026-09-10.
+
+## Endpoints
+
+```
+GET https://myvariant.info/v1/query?q={rsID or text}
+GET https://myvariant.info/v1/variant/{hg19_id}
+```
+
+`/variant/` ids look like `chr17:g.7578406C>G`. That is hg19. A GRCh38
+`g.` string on this endpoint 404s.
+
+## Verified calls
+
+```
+GET /v1/query?q=rs28934578
+```
+
+HTTP 200. First hit:
+
+| Field | Value |
+| --- | --- |
+| `_id` | `chr17:g.7578406C>G` |
+| `cadd.phred` | **35** |
+| `hg19.start` | 7578406 |
+
+Live CADD via VEP (`CADD=1`) for GRCh38 `17:7675088 C>G` the same day was
+**29.4**. If you report 35 as "the CADD score," you are reporting a cache.
+
+```
+GET /v1/variant/chr17:g.7674220G>A
+GET /v1/variant/chr17:g.7674220G>A?assembly=hg38
+GET /v1/variant/chr17:g.7577538G>A
+```
+
+All HTTP 404. `assembly=hg38` does not make a GRCh38 `g.` id valid here.
+Query by rsID, then use the returned `_id` if you need `/variant/`.
+
+## Traps
+
+- Default genome for `_id` is hg19. Write that down.
+- Cached `cadd.phred` is not live CADD v1.7. Treat a gap of ≥ 0.5 PHRED
+  as "this is not the score to write."
+- ClinVar fields here are a snippet. For a clinical assertion go to
+  `clinvar.md`.
+- Last call, not first. Do not start an annotation here and skip VEP.

--- a/skills/database-lookup/references/regulomedb.md
+++ b/skills/database-lookup/references/regulomedb.md
@@ -1,0 +1,62 @@
+# RegulomeDB
+
+Regulatory evidence for **noncoding** SNVs: ENCODE TF ChIP, DNase, motifs,
+QTLs. Rank `1a` (strongest) through `7` (nothing overlapping). Neighbour of
+`encode.md` and `jaspar.md`. Not a consequence scorer — for missense impact
+use Ensembl VEP (`ensembl.md` §6, `CADD=1`).
+
+Search: `https://regulomedb.org/regulome-search/`
+Help: https://regulomedb.org/regulome-help/
+All figures verified 2026-09-10.
+
+## Request
+
+```
+GET /regulome-search/?regions={rsID|chr:start-end}&genome=GRCh38&format=json
+```
+
+`genome` is `GRCh38` (preferred) or `GRCh37`. Default format is HTML.
+
+Coordinates are **0-based half-open**, same as BED. A single GRCh38 base
+at 1-based position `P` is `chrN:{P-1}-{P}`.
+
+## Verified calls
+
+```
+GET ...?regions=rs6983267&genome=GRCh38&format=json
+```
+
+`regulome_score.ranking` **1a**, `probability` **0.93**. This is the
+example of a regulatory hit.
+
+```
+GET ...?regions=rs28934578&genome=GRCh38&format=json
+GET ...?regions=chr17:7675087-7675088&genome=GRCh38&format=json
+```
+
+Both: ranking **4**, probability **0.60906**. A coding missense with rank
+4 is "not what this database is for," not "benign regulatory."
+
+```
+GET ...?regions=chr17:7674220-7674220&genome=GRCh38&format=json
+```
+
+HTTP 200, `variants: []`, no `regulome_score.ranking`. Zero-width /
+1-based same-number ranges miss the base.
+
+```
+POST /regulome-search/   with a JSON body
+```
+
+HTTP 200, `@id` `/regulome-notfound`, `@type` includes `regulome-help`.
+The old POST API is dead. Use GET.
+
+## Traps
+
+- Convert 1-based VEP/CADD positions before building `regions=`.
+- Read `regulome_score.ranking`, not a legacy `regulomedb_score` field.
+- `probability` is a string.
+- Region queries without an rsID return common SNPs (MAF > 1%) in the
+  window, not every possible SNV.
+- Rank 7 / missing ranking is "no annotated overlap," not a proof the
+  variant does nothing.


### PR DESCRIPTION
## Summary
- Reshaped onto `database-lookup` per review: no new skill. VEP and CADD already live in `ensembl.md` §6; RegulomeDB is the genuinely new source.
- New `references/regulomedb.md` (0-based window, ranks, dead POST) and a short `references/myvariant.md` framed as the cache to distrust.
- `ensembl.md` §6 replaces the stale `17:g.7674220G>A` example with live `17:g.7675088C>G` / `rs28934578`, documents `CADD=1` for `cadd_phred` 29.4, and records the two traps (`most_severe_consequence` spans every transcript; the region endpoint annotates the alt you type without checking the claimed ref).
- `metadata.version` `"1.5"` → `"1.6"`. Catalog count 78 → 80.

## Test plan
- [x] `uv run skills-ref validate skills/database-lookup`
- [x] `uv run --with pytest python -m pytest tests/_meta -q`
- [x] Live VEP `17:g.7675088C>G?CADD=1` → missense / TP53 / `cadd_phred` 29.4
- [ ] Coordinate with #260: that branch still edits `ensembl.md` and currently substitutes the stale genomic HGVS with `region/17:7674220-7674220/A`. This PR's `7675088C>G` is the live call.