### PR TITLE
Map the STAMPED properties onto DataLad commands

### DIFF
--- a/skills/datalad/SKILL.md
+++ b/skills/datalad/SKILL.md
@@ -5,7 +5,7 @@ compatibility: Needs datalad 1.6.x on Python 3.10+, plus git and git-annex 10.x.
 license: MIT
 allowed-tools: Read Write Edit Bash
 metadata:
-  version: "1.0"
+  version: "1.1"
   skill-author: Dylan Pulver
 ---
 
@@ -296,4 +296,7 @@ Topic scope for this skill was informed in part by @bcmcpher's MIT-licensed
 plugin (nineteen per-command slash-command skills). The text here is written
 independently and grounded in the upstream DataLad documentation; overlap is unavoidable
 because both cover DataLad, but the structure, style, and specific technical claims are
-different.
+different. The STAMPED requirement list, evidence map, and assessment procedure in
+[provenance.md](references/provenance.md) are the exception: they are adapted from that
+plugin's `stamped-principles.md` and `datalad-stamped-assess` skill, contributed by their
+author.

--- a/skills/datalad/references/provenance.md
+++ b/skills/datalad/references/provenance.md
@@ -43,6 +43,124 @@ Two companion resources make this checkable rather than aspirational:
 checklist, and <https://examples.stamped-principles.org> collects worked patterns,
 including ones built directly on `datalad run` and `datalad rerun`.
 
+### The normative requirements
+
+Each property is a spectrum rather than a pass/fail gate, and its requirements carry RFC 2119
+weights: MUST is the practical minimum a careful project usually already meets, SHOULD and MAY are
+progressively more tool-assisted. Grade an object requirement by requirement, citing the evidence
+behind each grade rather than the impression.
+
+| Item | Weight | Requirement |
+|---|---|---|
+| S.1 | MUST | Every module essential to replicating the execution is reachable within one top-level research object, either literally or by explicit reference |
+| S.2 | MUST | License declarations are retrievable alongside what they govern |
+| T.1 | MUST | Persistent content identification is recorded for all components |
+| T.2 | SHOULD | All components use the same content-addressed version control system |
+| T.3 | MUST | The provenance of all modifications is recorded |
+| T.4 | SHOULD, MUST | Code-driven provenance is captured programmatically (SHOULD), and it MUST include the versions of the components involved |
+| A.1 | MUST | Instructions sufficient to reproduce all results are present |
+| A.2 | SHOULD | Those procedures are executable specifications rather than prose |
+| M.1 | SHOULD | Components are organised modularly |
+| M.2 | MAY | Modules are included directly or linked as subdatasets |
+| M.3 | SHOULD | Each module declares its own license, checked for compatibility where modules combine |
+| P.1 | MUST NOT | Procedures depend on undocumented host state |
+| P.2 | MUST | Computational environments are explicitly specified |
+| P.3 | MUST | Environment definitions are version controlled |
+| E.1 | SHOULD | Results are produced in ephemeral environments rebuilt from those specifications |
+| D.1 | MUST | All referenced modules are persistently retrievable by others |
+| D.2 | SHOULD | Environment specifications support reproducible builds |
+| D.3 | SHOULD | Each module carries an explicit license with a resolvable identifier |
+
+The `S.1`-style labels are shorthand for walking the list in order, not identifiers taken from the
+specification; <https://checklist.stamped-principles.org> is the authority for the wording and the
+weights.
+
+### Where the evidence lives
+
+Every requirement above is checkable against a DataLad dataset with read-only commands. Nothing in
+this table writes to the dataset.
+
+| Property | What satisfies it | How to look |
+|---|---|---|
+| **S** | inputs registered as subdatasets rather than copied in, a top-level `README`, and a `LICENSE` beside the content it covers | `datalad subdatasets -r`, `cat .gitmodules`, `git annex whereis <path>` for content that lives elsewhere |
+| **T** | git history for structure, annex keys for content, run records for modifications | `git log --oneline`, `git log --oneline --grep '\[DATALAD RUNCMD\]'` to count run records, `git annex whereis --json <path>` for recorded locations |
+| **A** | replayable run records, not a prose README | `datalad rerun --report <rev>` on the commits that produced results; if that finds nothing, A.2 is unmet however good the README is |
+| **M** | `code/`, `inputs/`, `outputs/` separated, each linked module keeping its own history and license | `datalad subdatasets -r`, `git ls-files` for the layout, per-module `LICENSE` |
+| **P** | an environment specification tracked in Git, and commands that name no host-specific path | `git ls-files \| grep -Ei 'dockerfile\|environment.ya?ml\|requirements.txt\|pyproject.toml'`, `datalad containers-list`, and a read of the recorded commands for absolute paths outside the dataset |
+| **E** | results produced by `containers-run` against a registered image rather than by ambient tools | `datalad containers-list`, and whether the run records are `containers-run` invocations |
+| **D** | a sibling that others can actually reach, and content that is really there | `datalad siblings`, `git remote -v`, `git annex whereis --json <path> \| jq '.whereis \| length'` |
+
+Grep the commit subject rather than the run record markers. With `--sidecar yes`, or with
+`datalad.run.record-sidecar` set, the record itself is written to the dataset's `.datalad/runinfo`
+directory instead of into the commit message, but the `[DATALAD RUNCMD]` subject is there either
+way.
+
+`datalad containers-list` needs the `datalad-container` extension; without it installed the command
+does not exist, which is itself evidence about P and E. Where `datalad` is unavailable altogether,
+every probe above except `subdatasets`, `containers-list`, and `rerun --report` has a plain Git or
+git-annex equivalent, so a git-only assessment is still possible at reduced confidence — say so in
+the readout rather than reporting a gap you could not probe for.
+
+### Ephemeral and Distributable in practice
+
+These are the two properties a DataLad dataset is least likely to satisfy by accident, because
+neither follows from committing carefully.
+
+**Ephemeral (E.1)** asks that results come out of an environment rebuilt from specification, not
+out of whatever was installed on the machine that ran the analysis. `containers-run` is the
+mechanism: the documentation states that "the container image itself will be recorded as an input
+dependency of the command execution in the RUN record in the git history", so the record pins the
+image as annexed content addressed by key rather than as a tag someone can re-push under. A
+`Dockerfile` or `environment.yml` tracked in the dataset that *builds* that image is stronger still,
+because it satisfies P.2 and P.3 as well and gives D.2 something to reproduce from.
+
+One name collision worth heading off: `datalad clone --reckless ephemeral` has nothing to do with
+this property. It symlinks the clone's annex to the origin's and marks the clone dead to git-annex,
+which is a disk and inode optimisation for throwaway compute; it says nothing about how the
+environment was built.
+
+**Distributable (D.1)** fails most often in a way that looks like success. `datalad push --data`
+defaults to `auto-if-wanted`, so a push that reports success can move the history and none of the
+content, leaving a sibling that clones cleanly and then cannot deliver a single byte. Check the
+result rather than the exit status:
+
+```bash
+datalad push --to store --data anything
+git annex whereis --json <path> | jq '.whereis | length'   # more than the local annex?
+```
+
+Persistence is the other half, and a sibling on a lab server is not persistence. A RIA store keeps
+the full history and annex in one addressable place (see [publishing.md](publishing.md)); for an
+archived snapshot with an identifier, `datalad export-archive` writes a TAR or ZIP of the dataset
+content and `datalad export-to-figshare` pushes one to figshare, which is where a DOI enters. D.3
+then asks that the license carry a resolvable identifier: an SPDX identifier from
+<https://spdx.org/licenses/>, or the REUSE conventions at <https://reuse.software> when modules are
+licensed individually, which is also what makes M.3 checkable.
+
+### Assessing an existing dataset
+
+Assessment is read-only. Never `save`, `run`, `push`, or edit while grading: a report that mutates
+the object it grades invalidates itself.
+
+1. Confirm the target is a dataset at all (`.datalad/` present, or at least a Git repository), and
+   report the resolved path.
+2. Run the probes in the evidence table, collecting what each one shows and what it fails to show.
+3. Walk S.1 through D.3, marking each item satisfied, partial, or unmet against that evidence. An
+   unmet MUST outranks any number of unmet SHOULDs when ordering the result.
+4. Report per property, with the evidence attached, and lead with the shape of it — "strong on S, T,
+   and M, weak on P, E, and D" is the sentence a reader acts on:
+
+   | Property | Grade | Evidence | Gap |
+   |---|---|---|---|
+   | S Self-contained | partial | inputs are subdatasets (`.gitmodules`) | no top-level README |
+   | T Tracked | satisfied | 14 run records in history | — |
+
+5. If a remediation plan is wanted, order it by weight and make every step a command:
+   results with no run record → re-run under `datalad run` or `containers-run`; no environment
+   specification → add one and `containers-add` the image; inputs copied in → `datalad clone -d .`
+   into `inputs/`; no license → add one with an SPDX identifier; nothing published → `datalad push`
+   to a sibling or RIA store, then archive for a DOI.
+
 ### The YODA layout in practice
 
 Apply the layout at creation time:


### PR DESCRIPTION
# Summary

Fills the gap named in #227: the STAMPED section states
what each property requires but stops short of mapping it onto commands, and Ephemeral and
Distributable were the thinnest of the seven. One commit, all of it inside
`references/provenance.md` apart from four lines of the Acknowledgment.

This is the follow-up @TKassis invited when #227 merged. It supersedes
dylanpulver/scientific-agent-skills#2, which targeted `feat/datalad-skill` and can no longer
land there now that the branch is merged; the single commit is cherry-picked onto current
`main` rather than rebased, so none of @dylanpulver's already-merged commits come with it.
It carries the `metadata.version` bump to `"1.1"` that was asked for on that merge.

## Type of change

- [x] Update to an existing skill

## Skills touched

- datalad

## What this adds

Four subsections inside the existing `## Principles: STAMPED…` heading, all after the
companion-resources paragraph and before the YODA layout. The existing text is kept as it
stands — the seven-property table, the "Actionable is the property `datalad run` exists to
satisfy" paragraph, the YODA subsection, and the checklist and examples links are untouched.

**The normative requirements.** The requirements as an item-level list carrying their RFC 2119
weights, plus the framing that each property is a spectrum rather than a pass/fail gate. This
is the layer that makes the seven-row table gradeable: a reader can walk it and mark each item
rather than judge a property whole.

**Where the evidence lives.** A read-only probe for every property — `datalad subdatasets -r`
and `.gitmodules` for S and M, `git log --oneline --grep '[DATALAD RUNCMD]'` and
`git annex whereis --json` for T, `datalad rerun --report` for A, tracked environment
specifications and `datalad containers-list` for P and E, `datalad siblings` and a copy count
for D. This is the part named as missing in the #227 thread. Nothing in the table writes to
the dataset.

**Ephemeral and Distributable in practice.** The two thin rows. For E: `containers-run` records
the image as an input dependency, so the record pins bytes rather than a re-pushable tag, and a
tracked `Dockerfile` that builds that image is stronger still because it also carries P.2, P.3,
and D.2. For D: `push --data` defaulting to `auto-if-wanted` is why a push can report success
and leave a sibling that clones cleanly and delivers nothing, so the section gives the check
rather than the exit status, then separates "has a sibling" from "is persistently retrievable"
via RIA stores, `export-archive` / `export-to-figshare` for a DOI, and SPDX or REUSE for D.3.

**Assessing an existing dataset.** A read-only procedure ending in a per-property readout table
with evidence attached, and a remediation list ordered by RFC 2119 weight.

## How this was reshaped for this repository

The source is my `datalad-cli` plugin, which is nineteen per-command slash-command skills. That
shape does not survive the trip, so:

- Its evidence map's right-hand column names sibling skills (`/datalad-push`,
  `/datalad-container-run`). Here it names the command and the reference section, since this is
  one skill with `references/` beneath it.
- The `datalad-stamped-assess` skill became a procedure section rather than a second skill.
  AGENTS.md declines both orchestrator skills and a second skill for a tool already covered, and
  an assessment skill sitting beside `datalad` would be both.
- Its plugin-only frontmatter (`argument-hint`, `user-invocable`, `disable-model-invocation`)
  and its `${CLAUDE_PLUGIN_ROOT}` relative loading have no equivalent under the spec's six
  top-level fields, so they are gone along with `$ARGUMENTS` and `--plan`.
- The normative wording stayed close to verbatim, because it is normative.
- Frontmatter is otherwise untouched: the only change is `metadata.version` `"1.0"` → `"1.1"`.
  `skill-author` stays @dylanpulver — this is an addition to their skill, not a co-authorship
  claim. The attribution for the adapted material lives in the Acknowledgment instead.

The Acknowledgment currently says the text is written independently, which stops being true
once this lands, so it now names the adapted material. Reword or drop that as you prefer.

## What was verified against upstream

Given what the S3 sibling example cost in review, every command here was checked rather than
recalled — and re-checked for this PR against **datalad 1.6.2, datalad-container 1.2.6 and
git-annex 10.20250929**, the versions the skill's own `compatibility` line names, rather than
against whatever the shell happened to resolve. From installed `--help` output or the current
docs: `subdatasets -r`,
`status --annex {basic|availability|all}`, `rerun --report`, `push --data anything`,
`clone --reckless ephemeral`, `containers-list` (and that it is an extension command),
`export-archive`, and `export-to-figshare`.

Three things came back differently from what my own plugin says, and the difference is in this
diff rather than carried across:

- The run-record probe greps the `[DATALAD RUNCMD]` commit subject, not the
  `=== Do not change lines below ===` markers. With `--sidecar yes`, or with
  `datalad.run.record-sidecar` set, the record goes to `.datalad/runinfo` and a marker grep
  finds nothing; the subject is written either way.
- `checklist.stamped-principles.org` does not publish per-item identifiers, so the `S.1`-style
  labels are flagged in the text as walking shorthand rather than presented as spec identifiers.
- `datalad clone --reckless ephemeral` is unrelated to STAMPED's Ephemeral property — it
  symlinks the clone's annex to the origin's and marks the clone dead — and the section says so,
  because the collision is exactly the kind of thing an agent would conflate.

The copy count reuses the `git annex whereis --json <path> | jq '.whereis | length'` form
already in `data-access.md` rather than introducing a second spelling. The `containers-run`
claim is quoted from the datalad-container man page. The three URLs this adds —
checklist.stamped-principles.org, reuse.software, spdx.org/licenses — all return 200.

## How this was tested

```
uv run skills-ref validate ./skills/datalad          -> Valid skill: skills/datalad
for d in skills/*/; do uv run skills-ref validate "$d"; done   -> 165 validated, 0 failures
uv run python -m pytest tests/_meta -q               -> 10 passed, 1515 subtests passed
git diff --check                                     -> clean
```

`SKILL.md` is 302 lines, under the 500-line limit; `references/provenance.md` goes from 228 to
346. I did not run skill-scanner, on @dylanpulver's report in the #227 thread that its findings
vary between runs and describe DataLad itself; this change adds no scripts and no executable
content.

## Related issues and references

- Fills the request in #227 (comment of 2026-08-21) and the follow-up invitation on its merge.
- Supersedes dylanpulver/scientific-agent-skills#2, closed in favour of this.
- Source material: `references/stamped-principles.md` and `skills/datalad-stamped-assess/` in
  the MIT-licensed [datalad-cli](https://github.com/bcmcpher/my-skills/tree/main/plugins/datalad-cli)
  plugin, contributed here by their author.
- STAMPED: <https://stamped-principles.org>, <https://checklist.stamped-principles.org>
- `datalad run` man page (`--sidecar`, `.datalad/runinfo`):
  <https://docs.datalad.org/en/stable/generated/man/datalad-run.html>
- `datalad containers-run` man page (image recorded as an input dependency):
  <https://docs.datalad.org/projects/container/en/stable/generated/man/datalad-containers-run.html>

---

## Checklist

**Skill format**

- [x] The skill directory name and the `name` frontmatter match exactly.
- [x] The skill directory contains only `SKILL.md` and `references/`.
- [x] `SKILL.md` has valid YAML frontmatter and a Markdown body.
- [x] Only the six spec-defined top-level fields are present.
- [x] `metadata` is a block mapping with quoted scalars.
- [ ] Any `metadata.openclaw` or `metadata.hermes` block is a nested mapping — n/a, neither is present.
- [x] `metadata.version` bumped `"1.0"` → `"1.1"`.
- [x] The `description` says what the skill does and when to use it — unchanged by this PR.

**Validation and tests**

- [x] `uv run skills-ref validate ./skills/datalad` passes.
- [ ] Tests in `tests/datalad/` — n/a, the skill ships no `scripts/`, so per CONTRIBUTING there
      is no suite and no `skill-requirements.toml` entry.
- [x] `tests/_meta` passes: 10 passed, 1515 subtests.
- [ ] Security scanner — not run, see the testing section above.

**Content and safety**

- [x] Every command was checked against `--help` output or upstream docs.
- [x] No secrets, credentials, private data, or unsafe instructions.
- [ ] Credentials in `compatibility` / `metadata.openclaw.envVars` — n/a, unchanged by this PR.
- [x] Official documentation linked for each non-obvious claim.

## Notes for reviewers

The four new subsections sit inside the existing STAMPED heading rather than in a new one, on
the reasoning that STAMPED should have a single home in this skill and splitting the checkable
part into its own reference would separate it from the properties it grades. If you would rather
have `references/stamped.md`, moving the whole block is a clean cut — it is contiguous and
depends on nothing above it beyond the property table.

The evidence map is deliberately probes-only and says nothing about what to do with the result;
the remediation half is the last item of the assessment procedure. Happy to trim either if the
reference is getting long.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
